### PR TITLE
Fix for empty Hash and Array when converted to object_mask

### DIFF
--- a/lib/softlayer/base.rb
+++ b/lib/softlayer/base.rb
@@ -36,7 +36,7 @@
 #
 
 module SoftLayer
-  VERSION = "1.0.4"  # version history at the bottom of the file.
+  VERSION = "1.0.5"  # version history at the bottom of the file.
 
   # The base URL of the SoftLayer API's REST-like endpoints available to the public internet.
   API_PUBLIC_ENDPOINT = 'https://api.softlayer.com/rest/v3/'
@@ -76,4 +76,6 @@ end # module SoftLayer
 # JN.  Thanks!
 #
 # 1.0.4 - Fixed a bug where the result_limit and result_offset object filters were just not working. 
+#
+# 1.0.5 - Fixed a bug where empty hashes and empty arrays would not generate meaningful object masks
 #

--- a/lib/softlayer/object_mask_helpers.rb
+++ b/lib/softlayer/object_mask_helpers.rb
@@ -26,6 +26,8 @@
 
 class Hash
   def to_sl_object_mask(base = "")
+    return base if(self.empty?)
+    
     # ask the children to convert themselves with the key as the base
     masked_children = self.map { |key, value| result = value.to_sl_object_mask(key); }.flatten
 
@@ -36,6 +38,7 @@ end
 
 class Array
   def to_sl_object_mask(base = "")
+    return base if self.empty?
     self.map { |item| item.to_sl_object_mask(base) }.flatten
   end
 end

--- a/rakefile
+++ b/rakefile
@@ -24,11 +24,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-require 'rubygems'
-require 'rake/gempackagetask'
-require 'spec/rake/spectask'
 
+$: << File.expand_path(File.join(File.dirname(__FILE__)))
+
+require 'rubygems'
+require 'rubygems/package_task'
 require 'lib/softlayer/base'
+require 'rspec/core/rake_task'
 
 softlayer_api_gem = Gem::Specification.new do |s|
   s.platform  =   Gem::Platform::RUBY
@@ -60,16 +62,13 @@ softlayer_api_jruby_gem = Gem::Specification.new do |s|
   s.add_dependency("json-jruby")
 end
 
-Rake::GemPackageTask.new(softlayer_api_gem) do |pkg|
+Gem::PackageTask.new(softlayer_api_gem) do |pkg|
 end
 
-Rake::GemPackageTask.new(softlayer_api_jruby_gem) do |pkg|
-end
-
-Spec::Rake::SpecTask.new do |tester|
-  $DEBUG = 1
-  tester.spec_files = FileList["test/**/*.rb"]
-  tester.spec_opts = ["-c", "-f nested"]
+RSpec::Core::RakeTask.new do |tester|
+	$DEBUG = 1
+	tester.pattern = 'test/*.rb'
+	tester.rspec_opts = ["-c", "-f nested"]
 end
 
 task :default => [:spec] do

--- a/test/SoftLayer_APIParameterFilter.rb
+++ b/test/SoftLayer_APIParameterFilter.rb
@@ -28,7 +28,7 @@ $: << File.expand_path(File.join(File.dirname(__FILE__), "../lib"))
 
 require 'rubygems'
 require 'softlayer_api'
-require 'spec'
+require 'rspec'
 
 describe SoftLayer::APIParameterFilter, "#object_with_id" do
   it "should intitialize with empty parameter values" do

--- a/test/SoftLayer_Service.rb
+++ b/test/SoftLayer_Service.rb
@@ -28,8 +28,8 @@ $: << File.expand_path(File.join(File.dirname(__FILE__), "../lib"))
 
 require 'rubygems'
 require 'softlayer_api'
-require 'spec'
-require 'spec/autorun'
+require 'rspec'
+require 'rspec/autorun'
 
 describe SoftLayer::Service, "#new" do
   before(:each) do

--- a/test/SoftLayer_ToObjectMask.rb
+++ b/test/SoftLayer_ToObjectMask.rb
@@ -28,8 +28,8 @@ $: << File.expand_path(File.join(File.dirname(__FILE__), "../lib"))
 
 require 'rubygems'
 require 'softlayer_api'
-require 'spec'
-require 'spec/autorun'
+require 'rspec'
+require 'rspec/autorun'
 
 describe String, "#to_sl_object_mask" do
   it "should echo back a string with no base" do
@@ -50,8 +50,8 @@ describe String, "#to_sl_object_mask" do
 end
 
 describe Array,"#to_sl_object_mask" do
-  it "should return the empty array if run on an empty array" do
-    [].to_sl_object_mask.should eql([])
+  it "should return and empty string if run on an empty array" do
+    [].to_sl_object_mask.should eql("")
   end
 
   it "should call to_sl_object_mask passing the base to all its elements" do
@@ -70,6 +70,10 @@ describe Array,"#to_sl_object_mask" do
 end
 
 describe Hash, "#to_sl_object_mask" do
+  it "should return an empty string if run on an empty hash" do
+	  {}.to_sl_object_mask.should eql("")
+  end
+
   it "should call to_sl_object_mask on values with the key as the base" do
     proxy = "value"
     proxy.should_receive(:to_sl_object_mask).with("key").and_return("key.value")
@@ -80,4 +84,9 @@ describe Hash, "#to_sl_object_mask" do
   it "should resolve the mapped values with the base provided" do
     {"top" => [ "middle1", {"middle2" => "end"}]}.to_sl_object_mask.should eql(["top.middle1", "top.middle2.end"])
   end
+  
+  it "should handle a complex hash object mask with an inner empty hash" do
+    { "ipAddress" => { "ipAddress" => {}}}.to_sl_object_mask.should eql(["ipAddress.ipAddress"])
+  end
+  
 end


### PR DESCRIPTION
Fixed a bug when converting hashes and arrays to object masks.  Updated packaging and testing tools to work with modern versions of RubyGems and RSpec
