### PR TITLE
updating JSON gem to ~> 1.8.1 for compatibility with newer gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
-gem 'json', '~> 1.5', '>= 1.5.2'
+gem 'json', '~> 1.8.1'
 gem 'rake'
 gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,20 +3,20 @@ GEM
   specs:
     diff-lcs (1.2.5)
     json (1.8.1)
-    rake (10.1.0)
+    rake (10.1.1)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
     rspec-core (2.14.7)
-    rspec-expectations (2.14.4)
+    rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.4)
+    rspec-mocks (2.14.6)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  json (~> 1.5, >= 1.5.2)
+  json (~> 1.8.1)
   rake
   rspec


### PR DESCRIPTION
The older JSON version (1.5.2) was causing issues with some newer gems such as Sidekiq.

All tests pass with JSON 1.8.1.
