### PR TITLE
Fix broken gem configparser dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 *.*~
 *.gem
-
+.bundle/
 log/
 internal_examples/

--- a/CHANGELOG.textile
+++ b/CHANGELOG.textile
@@ -1,3 +1,6 @@
+*2.0.1*
+* Fix broken gem configparser dependency
+
 *2.0.0*
 * Switched the Ruby API client to use XML-RPC when calling the SoftLayer API rather than using the REST-like interface.
 * Result limits are now specified using @result_limit(offset,limit)@.

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'rake'
-gem 'rspec'
-gem 'configparser', "~> 0.1.2", :require => false
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,16 @@
+PATH
+  remote: .
+  specs:
+    softlayer_api (2.0.1)
+      configparser (~> 0.1.2)
+      json (~> 1.8, >= 1.8.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    configparser (0.1.2)
+    configparser (0.1.3)
     diff-lcs (1.2.5)
+    json (1.8.1)
     rake (10.1.1)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -18,6 +26,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  configparser (~> 0.1.2)
   rake
   rspec
+  softlayer_api!

--- a/lib/softlayer/base.rb
+++ b/lib/softlayer/base.rb
@@ -31,7 +31,7 @@ require 'rubygems'
 # - <tt>$SL_API_BASE_URL</tt>- The default URL used to access the SoftLayer API. This defaults to the value of <tt>SoftLayer::API_PUBLIC_ENDPOINT</tt>
 #
 module SoftLayer
-  VERSION = "2.0.0"  # version history in the CHANGELOG.textile file at the root of the source
+  VERSION = "2.0.1"  # version history in the CHANGELOG.textile file at the root of the source
 
   # The base URL of the SoftLayer API's REST-like endpoints available to the public internet.
   API_PUBLIC_ENDPOINT = 'https://api.softlayer.com/xmlrpc/v3/'

--- a/softlayer_api.gemspec
+++ b/softlayer_api.gemspec
@@ -37,6 +37,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.has_rdoc = true
+  s.add_dependency 'configparser', '~> 0.1.2'
   s.add_runtime_dependency 'json', '~> 1.8', '>= 1.8.1'
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
The configparser gem is being used now in the library, but it is only specified in the Gemfile, which is not included when the gem is packaged up. Hence, when I pull the new softlayer_api gem into my project and run `bundle install`, configparser is not installed, and I get a runtime error about this missing dependency from the softlayer_api gem.

All these dependencies should be declared in the .gemspec instead. The Gemfile is usually for projects deployed as apps (or dev deps), rather than libraries like this one.

More information about this at http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
