### PR TITLE
V3.0: Removing explicit receiver for private method calls in VirtualServerUpgradeOrder(verify, place_order!)

### DIFF
--- a/lib/softlayer/VirtualServerUpgradeOrder.rb
+++ b/lib/softlayer/VirtualServerUpgradeOrder.rb
@@ -51,10 +51,9 @@ module SoftLayer
     #
     def verify()
       if has_order_items?
-        order_object = self.order_object
-        order_object = yield order_object if block_given?
-
-        @virtual_server.softlayer_client[:Product_Order].verifyOrder(order_object)
+        order_obj = order_object
+        order_obj = yield order_object if block_given?
+        @virtual_server.softlayer_client[:Product_Order].verifyOrder(order_obj)
       end
     end
 
@@ -67,8 +66,8 @@ module SoftLayer
     #
     def place_order!()
       if has_order_items?
-        order_object = self.order_object
-        order_object = yield order_object if block_given?
+        order_obj = order_object
+        order_obj = yield order_object if block_given?
 
         @virtual_server.softlayer_client[:Product_Order].placeOrder(order_object)
       end
@@ -113,7 +112,7 @@ module SoftLayer
     # and whose capacity matches the value given. Returns the item_price or nil
     #
     def _item_price_with_capacity(which_category, capacity)
-      self._item_prices_in_category(which_category).find { |item_price| item_price['item']['capacity'].to_i == capacity}
+      _item_prices_in_category(which_category).find { |item_price| item_price['item']['capacity'].to_i == capacity}
     end
 
     ##

--- a/lib/softlayer/VirtualServerUpgradeOrder.rb
+++ b/lib/softlayer/VirtualServerUpgradeOrder.rb
@@ -51,9 +51,9 @@ module SoftLayer
     #
     def verify()
       if has_order_items?
-        order_obj = order_object
-        order_obj = yield order_object if block_given?
-        @virtual_server.softlayer_client[:Product_Order].verifyOrder(order_obj)
+        order_template = order_object
+        order_template = yield order_object if block_given?
+        @virtual_server.softlayer_client[:Product_Order].verifyOrder(order_template)
       end
     end
 
@@ -66,10 +66,10 @@ module SoftLayer
     #
     def place_order!()
       if has_order_items?
-        order_obj = order_object
-        order_obj = yield order_object if block_given?
+        order_template = order_object
+        order_template = yield order_object if block_given?
 
-        @virtual_server.softlayer_client[:Product_Order].placeOrder(order_object)
+        @virtual_server.softlayer_client[:Product_Order].placeOrder(order_template)
       end
     end
 


### PR DESCRIPTION
In order to resolve a NoMethodError when placing or verifying a VirtualServerUpgradeOrder, I removed the "self" receivers from the verify, place_order!, and _item_price_with_capacity methods in VirtualServerUpgradeOrder.rb. 

To reproduce, please review this sample: 

```ruby
vg_upgrade_order = SoftLayer::VirtualServerUpgradeOrder.new(vg)
vg_upgrade_order.ram = 4
vg_upgrade_order.place_order!
```
The stack dump is provided below:

```ruby 

c:/Ruby193/lib/ruby/gems/1.9.1/gems/softlayer_api-3.0.1/lib/softlayer/VirtualServerUpgradeOrder.rb:69:in `place_order!': private method `order_object' called for #<SoftLayer::VirtualServerUpgradeOrder:0x3cd2510> (NoMetho
dError)
        from c:/Users/IBM_ADMIN/workspace/john-v3-softlayer-api-wrapper_src/bin/sl_cli.rb:50:in `upgrade'
        from c:/Ruby193/lib/ruby/gems/1.9.1/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from c:/Ruby193/lib/ruby/gems/1.9.1/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from c:/Ruby193/lib/ruby/gems/1.9.1/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from c:/Ruby193/lib/ruby/gems/1.9.1/gems/thor-0.19.1/lib/thor/invocation.rb:115:in `invoke'
        from c:/Ruby193/lib/ruby/gems/1.9.1/gems/thor-0.19.1/lib/thor.rb:235:in `block in subcommand'
        from c:/Ruby193/lib/ruby/gems/1.9.1/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from c:/Ruby193/lib/ruby/gems/1.9.1/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from c:/Ruby193/lib/ruby/gems/1.9.1/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from c:/Ruby193/lib/ruby/gems/1.9.1/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from sl:4:in `<main>'
```