### PR TITLE
Add new ObjectFilter helper methods and cleanup usage of ObjectFilters

### DIFF
--- a/lib/softlayer/BareMetalServer.rb
+++ b/lib/softlayer/BareMetalServer.rb
@@ -183,15 +183,15 @@ module SoftLayer
     #
     # You may filter the list returned by adding options:
     #
-    # * <b>+:tags+</b> (array) - an array of strings representing tags to search for on the instances
-    # * <b>+:cpus+</b> (int) - return servers with the given number of (virtual) CPUs
-    # * <b>+:memory+</b> (int) - return servers with at least the given amount of memory (in Gigabytes)
-    # * <b>+:hostname+</b> (string) - return servers whose hostnames match the query string given (see ObjectFilter::query_to_filter_operation)
-    # * <b>+:domain+</b> (string) - filter servers to those whose domain matches the query string given (see ObjectFilter::query_to_filter_operation)
-    # * <b>+:datacenter+</b> (string) - find servers whose data center name matches the query string given (see ObjectFilter::query_to_filter_operation)
-    # * <b>+:nic_speed+</b> (int) - include servers with the given nic speed (in Mbps)
-    # * <b>+:public_ip+</b> (string) - return servers whose public IP address matches the query string given (see ObjectFilter::query_to_filter_operation)
-    # * <b>+:private_ip+</b> (string) - same as :public_ip, but for private IP addresses
+    # * <b>+:tags+</b>       (string/array) - an array of strings representing tags to search for on the instances
+    # * <b>+:cpus+</b>       (int/array)    - return servers with the given number of (virtual) CPUs
+    # * <b>+:memory+</b>     (int/array)    - return servers with at least the given amount of memory (in Gigabytes)
+    # * <b>+:hostname+</b>   (string/array) - return servers whose hostnames match the query string given (see ObjectFilter::query_to_filter_operation)
+    # * <b>+:domain+</b>     (string/array) - filter servers to those whose domain matches the query string given (see ObjectFilter::query_to_filter_operation)
+    # * <b>+:datacenter+</b> (string/array) - find servers whose data center name matches the query string given (see ObjectFilter::query_to_filter_operation)
+    # * <b>+:nic_speed+</b>  (int/array)    - include servers with the given nic speed (in Mbps)
+    # * <b>+:public_ip+</b>  (string/array) - return servers whose public IP address matches the query string given (see ObjectFilter::query_to_filter_operation)
+    # * <b>+:private_ip+</b> (string/array) - same as :public_ip, but for private IP addresses
     #
     # Additionally you may provide options related to the request itself:
     #
@@ -210,14 +210,15 @@ module SoftLayer
       end
 
       option_to_filter_path = {
-        :cpus => "hardware.processorPhysicalCoreAmount",
-        :memory => "hardware.memoryCapacity",
-        :hostname => "hardware.hostname",
-        :domain => "hardware.domain",
+        :cpus       => "hardware.processorPhysicalCoreAmount",
+        :memory     => "hardware.memoryCapacity",
+        :hostname   => "hardware.hostname",
+        :domain     => "hardware.domain",
         :datacenter => "hardware.datacenter.name",
-        :nic_speed => "hardware.networkComponents.maxSpeed",
-        :public_ip => "hardware.primaryIpAddress",
-        :private_ip => "hardware.primaryBackendIpAddress"
+        :nic_speed  => "hardware.networkComponents.maxSpeed",
+        :public_ip  => "hardware.primaryIpAddress",
+        :private_ip => "hardware.primaryBackendIpAddress",
+        :tags       => "hardware.tagReferences.tag.name"
       }
 
       # For each of the options in the option_to_filter_path map, if the options hash includes
@@ -225,17 +226,6 @@ module SoftLayer
       # value
       option_to_filter_path.each do |option, filter_path|
         object_filter.modify { |filter| filter.accept(filter_path).when_it is(options_hash[option])} if options_hash[option]
-      end
-
-      # Tags get a much more complex object filter operation so we handle them separately
-      if options_hash.has_key?(:tags)
-        object_filter.set_criteria_for_key_path("hardware.tagReferences.tag.name", {
-          'operation' => 'in',
-          'options' => [{
-            'name' => 'data',
-            'value' => options_hash[:tags].collect{ |tag_value| tag_value.to_s }
-            }]
-          } );
       end
 
       account_service = softlayer_client[:Account]

--- a/lib/softlayer/ImageTemplate.rb
+++ b/lib/softlayer/ImageTemplate.rb
@@ -209,8 +209,9 @@ module SoftLayer
     # If no client can be found the routine will raise an error.
     #
     # Additional options that may be provided:
-    # * <b>+:name+</b> (string) - Return templates with the given name
-    # * <b>+:global_id+</b> (string) - Return templates with the given global identfier
+    # * <b>+:name+</b>      (string/array) - Return templates with the given name
+    # * <b>+:global_id+</b> (string/array) - Return templates with the given global identfier
+    # * <b>+:tags+</b>      (string/array) - Return templates with the tags
     def self.find_private_templates(options_hash = {})
       softlayer_client = options_hash[:client] || Client.default_client
       raise "#{__method__} requires a client but none was given and Client::default_client is not set" if !softlayer_client
@@ -223,8 +224,9 @@ module SoftLayer
       end
 
       option_to_filter_path = {
-        :name => "privateBlockDeviceTemplateGroups.name",
+        :name      => "privateBlockDeviceTemplateGroups.name",
         :global_id => "privateBlockDeviceTemplateGroups.globalIdentifier",
+        :tags      => "privateBlockDeviceTemplateGroups.tagReferences.tag.name"
       }
 
       # For each of the options in the option_to_filter_path map, if the options hash includes
@@ -232,17 +234,6 @@ module SoftLayer
       # value
       option_to_filter_path.each do |option, filter_path|
         object_filter.modify { |filter| filter.accept(filter_path).when_it is(options_hash[option])} if options_hash[option]
-      end
-
-      # Tags get a much more complex object filter operation so we handle them separately
-      if options_hash.has_key?(:tags)
-        object_filter.set_criteria_for_key_path("privateBlockDeviceTemplateGroups.tagReferences.tag.name", {
-          'operation' => 'in',
-          'options' => [{
-            'name' => 'data',
-            'value' => options_hash[:tags].collect{ |tag_value| tag_value.to_s }
-            }]
-          } );
       end
 
       account_service = softlayer_client[:Account]
@@ -275,8 +266,9 @@ module SoftLayer
     # If no client can be found the routine will raise an error.
     #
     # Additional options that may be provided:
-    # * <b>+:name+</b> (string) - Return templates with the given name
-    # * <b>+:global_id+</b> (string) - Return templates with the given global identfier
+    # * <b>+:name+</b>      (string/array) - Return templates with the given name
+    # * <b>+:global_id+</b> (string/array) - Return templates with the given global identfier
+    # * <b>+:tags+</b>      (string/array) - Return templates with the tags
     def self.find_public_templates(options_hash = {})
       softlayer_client = options_hash[:client] || Client.default_client
       raise "#{__method__} requires a client but none was given and Client::default_client is not set" if !softlayer_client
@@ -289,8 +281,9 @@ module SoftLayer
       end
 
       option_to_filter_path = {
-        :name => "name",
+        :name      => "name",
         :global_id => "globalIdentifier",
+        :tags      => "tagReferences.tag.name"
       }
 
       # For each of the options in the option_to_filter_path map, if the options hash includes
@@ -298,17 +291,6 @@ module SoftLayer
       # value
       option_to_filter_path.each do |option, filter_path|
         object_filter.modify { |filter| filter.accept(filter_path).when_it is(options_hash[option])} if options_hash[option]
-      end
-      
-      # Tags get a much more complex object filter operation so we handle them separately
-      if options_hash.has_key?(:tags)
-        object_filter.set_criteria_for_key_path("tagReferences.tag.name", {
-          'operation' => 'in',
-          'options' => [{
-            'name' => 'data',
-            'value' => options_hash[:tags].collect{ |tag_value| tag_value.to_s }
-            }]
-          } );
       end
 
       template_service = softlayer_client[:Virtual_Guest_Block_Device_Template_Group]

--- a/lib/softlayer/NetworkComponent.rb
+++ b/lib/softlayer/NetworkComponent.rb
@@ -5,7 +5,7 @@
 #++
 
 module SoftLayer
-	class NetworkComponent < SoftLayer::ModelBase
+  class NetworkComponent < SoftLayer::ModelBase
     sl_attr :name
     sl_attr :port
     sl_attr :speed

--- a/lib/softlayer/ProductPackage.rb
+++ b/lib/softlayer/ProductPackage.rb
@@ -155,7 +155,7 @@ module SoftLayer
 
     ##
     # Requests a list (array) of ProductPackages whose key names match the
-    # one passed in.
+    # one passed in. key_name may be a string or array.
     #
     def self.packages_with_key_name(key_name, client = nil)
       softlayer_client = client || Client.default_client

--- a/lib/softlayer/Ticket.rb
+++ b/lib/softlayer/Ticket.rb
@@ -5,7 +5,7 @@
 #++
 
 module SoftLayer
-	class Ticket < SoftLayer::ModelBase
+  class Ticket < SoftLayer::ModelBase
 
     ##
     # :attr_reader:
@@ -35,12 +35,12 @@ module SoftLayer
       self['serverAdministrationFlag'] != 0
     end
 
-		##
-		# Add an update to this ticket.
-		#
-		def update(body = nil)
-			self.service.edit(self.softlayer_hash, body)
-		end
+    ##
+    # Add an update to this ticket.
+    #
+    def update(body = nil)
+      self.service.edit(self.softlayer_hash, body)
+    end
 
     ##
     # Override of service from ModelBase. Returns the SoftLayer_Ticket service
@@ -52,7 +52,7 @@ module SoftLayer
     ##
     # Override from model base. Requests new details about the ticket
     # from the server.
-		def softlayer_properties(object_mask = nil)
+    def softlayer_properties(object_mask = nil)
       my_service = self.service
 
       if(object_mask)
@@ -62,12 +62,12 @@ module SoftLayer
       end
 
       my_service.getObject()
-		end
+    end
 
     ##
     # Returns the default object mask,as a hash, that is used when
     # retrieving ticket information from the SoftLayer server.
-		def self.default_object_mask
+    def self.default_object_mask
       {
         "mask" => [
           'id',							# This is an internal ticket ID, not the one usually seen in the portal
@@ -84,23 +84,23 @@ module SoftLayer
           'serverAdministrationFlag',   # This comes in from the server as an integer :-(
         ]
       }.to_sl_object_mask
-		end
+    end
 
     ##
     # Queries the SoftLayer API to retrieve a list of the valid
     # ticket subjects.
-		def self.ticket_subjects(client = nil)
-			@ticket_subjects ||= nil
+    def self.ticket_subjects(client = nil)
+      @ticket_subjects ||= nil
 
-			if !@ticket_subjects
+      if !@ticket_subjects
         softlayer_client = client || Client.default_client
         raise "#{__method__} requires a client but none was given and Client::default_client is not set" if !softlayer_client
 
-				@ticket_subjects = softlayer_client[:Ticket_Subject].getAllObjects();
-			end
+        @ticket_subjects = softlayer_client[:Ticket_Subject].getAllObjects();
+      end
 
-			@ticket_subjects
-		end
+      @ticket_subjects
+    end
 
     ##
     # Find the ticket with the given ID and return it
@@ -112,7 +112,7 @@ module SoftLayer
     # If a client is not provided then the routine will search Client::default_client
     # If Client::default_client is also nil the routine will raise an error.
     #
-		def self.ticket_with_id(ticket_id, options = {})
+    def self.ticket_with_id(ticket_id, options = {})
       softlayer_client = options[:client] || Client.default_client
       raise "#{__method__} requires a client but none was given and Client::default_client is not set" if !softlayer_client
 
@@ -167,5 +167,5 @@ module SoftLayer
       ticket_data = softlayer_client[:Ticket].createStandardTicket(new_ticket, body)
       return new(softlayer_client, ticket_data)
     end
-	end
+  end
 end

--- a/lib/softlayer/VLANFirewall.rb
+++ b/lib/softlayer/VLANFirewall.rb
@@ -17,7 +17,7 @@ module SoftLayer
   # As a result, instances of this class correspond to certain instances
   # in the SoftLayer_Network_Vlan service.
   #
-	class VLANFirewall < SoftLayer::ModelBase
+  class VLANFirewall < SoftLayer::ModelBase
     include ::SoftLayer::DynamicAttribute
 
     ##
@@ -218,7 +218,6 @@ module SoftLayer
       vlan_firewalls = softlayer_client[:Account].object_mask(vlan_firewall_mask).object_filter(vlan_firewall_filter).getNetworkVlans
       vlan_firewalls.collect { |firewall_data| SoftLayer::VLANFirewall.new(softlayer_client, firewall_data)}
     end
-
 
     #--
     # Methods for the SoftLayer model

--- a/lib/softlayer/VirtualServer.rb
+++ b/lib/softlayer/VirtualServer.rb
@@ -187,18 +187,18 @@ module SoftLayer
     # If no client can be found the routine will raise an error.
     #
     # You may filter the list returned by adding options:
-    # * <b>+:hourly+</b> (boolean) - Include servers billed hourly in the list
-    # * <b>+:monthly+</b> (boolean) - Include servers billed monthly in the list
-    # * <b>+:tags+</b> (array) - an array of strings representing tags to search for on the instances
-    # * <b>+:cpus+</b> (int) - return virtual servers with the given number of (virtual) CPUs
-    # * <b>+:memory+</b> (int) - return servers with at least the given amount of memory (in MB. e.g. 4096 = 4GB)
-    # * <b>+:hostname+</b> (string) - return servers whose hostnames match the query string given (see ObjectFilter::query_to_filter_operation)
-    # * <b>+:domain+</b> (string) - filter servers to those whose domain matches the query string given (see ObjectFilter::query_to_filter_operation)
-    # * <b>+:local_disk+</b> (boolean) - include servers that do, or do not, have local disk storage
-    # * <b>+:datacenter+</b> (string) - find servers whose short data center name (e.g. dal05, sjc01) matches the query string given (see ObjectFilter::query_to_filter_operation)
-    # * <b>+:nic_speed+</b> (int) - include servers with the given nic speed (in Mbps, usually 10, 100, or 1000)
-    # * <b>+:public_ip+</b> (string) - return servers whose public IP address matches the query string given (see ObjectFilter::query_to_filter_operation)
-    # * <b>+:private_ip+</b> (string) - same as :public_ip, but for private IP addresses
+    # * <b>+:hourly+</b>     (boolean)      - Include servers billed hourly in the list
+    # * <b>+:monthly+</b>    (boolean)      - Include servers billed monthly in the list
+    # * <b>+:tags+</b>       (string/array) - an array of strings representing tags to search for on the instances
+    # * <b>+:cpus+</b>       (int/array)    - return virtual servers with the given number of (virtual) CPUs
+    # * <b>+:memory+</b>     (int/array)    - return servers with at least the given amount of memory (in MB. e.g. 4096 = 4GB)
+    # * <b>+:hostname+</b>   (string/array) - return servers whose hostnames match the query string given (see ObjectFilter::query_to_filter_operation)
+    # * <b>+:domain+</b>     (string/array) - filter servers to those whose domain matches the query string given (see ObjectFilter::query_to_filter_operation)
+    # * <b>+:local_disk+</b> (boolean)      - include servers that do, or do not, have local disk storage
+    # * <b>+:datacenter+</b> (string/array) - find servers whose short data center name (e.g. dal05, sjc01) matches the query string given (see ObjectFilter::query_to_filter_operation)
+    # * <b>+:nic_speed+</b>  (int/array)    - include servers with the given nic speed (in Mbps, usually 10, 100, or 1000)
+    # * <b>+:public_ip+</b>  (string/array) - return servers whose public IP address matches the query string given (see ObjectFilter::query_to_filter_operation)
+    # * <b>+:private_ip+</b> (string/array) - same as :public_ip, but for private IP addresses
     #
     # Additionally you may provide options related to the request itself:
     # * <b>+:object_mask+</b> (string) - A object mask of properties, in addition to the default properties, that you wish to retrieve for the servers
@@ -216,15 +216,16 @@ module SoftLayer
       end
 
       option_to_filter_path = {
-        :cores => "virtualGuests.maxCpu",
-        :memory => "virtualGuests.maxMemory",
-        :hostname => "virtualGuests.hostname",
-        :domain => "virtualGuests.domain",
+        :cores      => "virtualGuests.maxCpu",
+        :memory     => "virtualGuests.maxMemory",
+        :hostname   => "virtualGuests.hostname",
+        :domain     => "virtualGuests.domain",
         :local_disk => "virtualGuests.localDiskFlag",
         :datacenter => "virtualGuests.datacenter.name",
-        :nic_speed => "virtualGuests.networkComponents.maxSpeed",
-        :public_ip => "virtualGuests.primaryIpAddress",
-        :private_ip => "virtualGuests.primaryBackendIpAddress"
+        :nic_speed  => "virtualGuests.networkComponents.maxSpeed",
+        :public_ip  => "virtualGuests.primaryIpAddress",
+        :private_ip => "virtualGuests.primaryBackendIpAddress",
+        :tags       => "virtualGuests.tagReferences.tag.name"
       }
 
       if options_hash.has_key?(:local_disk) then
@@ -236,17 +237,6 @@ module SoftLayer
       # value
       option_to_filter_path.each do |option, filter_path|
         object_filter.modify { |filter| filter.accept(filter_path).when_it is(options_hash[option])} if options_hash[option]
-      end
-
-      # Tags get a much more complex object filter operation so we handle them separately
-      if options_hash.has_key?(:tags)
-        object_filter.set_criteria_for_key_path("virtualGuests.tagReferences.tag.name", {
-          'operation' => 'in',
-          'options' => [{
-            'name' => 'data',
-            'value' => options_hash[:tags].collect{ |tag_value| tag_value.to_s }
-            }]
-          } );
       end
 
       required_properties_mask = 'mask.id'

--- a/lib/softlayer_api.rb
+++ b/lib/softlayer_api.rb
@@ -5,6 +5,7 @@
 #++
 
 # requirements from the core libraries
+require 'date'
 require 'time'
 
 # Requirements for the Foundation Layer


### PR DESCRIPTION
This adds is_contained_by, is_not_contained_by, and is_between_dates object filters as well as changing the behavior of is and is_not object filters to allow single value or Enumerable value (which gets passed on to is_contained_by and is_not_contained_by respectively) allowing for cleaner code and more flexible filtering.

This adds missing functionality described in #93 until further docs become available.