### PR TITLE
Fix incorrect rdoc for simple case where sl_attr is specified with two args

### DIFF
--- a/lib/softlayer/Account.rb
+++ b/lib/softlayer/Account.rb
@@ -58,7 +58,7 @@ module SoftLayer
 
     ##
     # :attr_reader:
-    # The office phone nubmer listed for the primary contact
+    # The office phone number listed for the primary contact
     sl_attr :officePhone
 
     ##
@@ -108,7 +108,7 @@ module SoftLayer
     end
 
     ##
-    # Retrieve an account's network message delivery acounts.
+    # Retrieve an account's network message delivery accounts.
     sl_dynamic_attr :network_message_delivery_accounts do |net_msg_deliv_accts|
       net_msg_deliv_accts.should_update? do
         @network_message_delivery_accounts == nil

--- a/lib/softlayer/Account.rb
+++ b/lib/softlayer/Account.rb
@@ -62,7 +62,7 @@ module SoftLayer
     sl_attr :officePhone
 
     ##
-    # The Bare Metal Servers (physical hardware) associated with the
+    # Retrieve the Bare Metal Servers (physical hardware) associated with the
     # account. Unless you force these to update, they will be refreshed every
     # five minutes.
     # :call-seq:
@@ -82,6 +82,8 @@ module SoftLayer
     ##
     # Retrieve an account's master EVault user. This is only used when an account
     # has an EVault service.
+    # :call-seq:
+    #   evault_master_users(force_update=false)
     sl_dynamic_attr :evault_master_users do |evault_users|
       evault_users.should_update? do
         @evault_master_users == nil
@@ -94,7 +96,10 @@ module SoftLayer
     end
 
     ##
-    # Retrieve an account's image templates
+    # Retrieve an account's image templates. Unless you force 
+    # these to update, they will be refreshed every five minutes
+    # :call-seq:
+    #   image_templates(force_update=false)
     sl_dynamic_attr :image_templates do |image_templates|
       image_templates.should_update? do
         @last_image_template_update ||= Time.at(0)
@@ -109,6 +114,8 @@ module SoftLayer
 
     ##
     # Retrieve an account's network message delivery accounts.
+    # :call-seq:
+    #   network_message_delivery_accounts(force_update=false)
     sl_dynamic_attr :network_message_delivery_accounts do |net_msg_deliv_accts|
       net_msg_deliv_accts.should_update? do
         @network_message_delivery_accounts == nil
@@ -122,6 +129,8 @@ module SoftLayer
 
     ##
     # Retrieve an account's network storage groups.
+    # :call-seq:
+    #   network_storage_groups(force_update=false)
     sl_dynamic_attr :network_storage_groups do |net_stor_groups|
       net_stor_groups.should_update? do
         @network_storage_groups == nil
@@ -134,7 +143,10 @@ module SoftLayer
     end
 
     ##
-    # Retrieve an account's open tickets
+    # Retrieve an account's open tickets. Unless you force these 
+    # to update, they will be refreshed every five minutes
+    # :call-seq:
+    #   open_tickets(force_update=false)
     sl_dynamic_attr :open_tickets do |open_tickets|
       open_tickets.should_update? do
         @last_open_tickets_update ||= Time.at(0)
@@ -150,6 +162,8 @@ module SoftLayer
 
     ##
     # Retrieve an account's portal users.
+    # :call-seq:
+    #   users(force_update=false)
     sl_dynamic_attr :users do |users|
       users.should_update? do
         @users == nil
@@ -162,7 +176,10 @@ module SoftLayer
     end
 
     ##
-    # Retrieve an account's virtual disk images
+    # Retrieve an account's virtual disk images. Unless you force 
+    # these to update, they will be refreshed every five minutes
+    # :call-seq:
+    #   virtual_disk_images(force_update=false)
     sl_dynamic_attr :virtual_disk_images do |virtual_disk_images|
       virtual_disk_images.should_update? do
         @last_virtual_disk_images_update ||= Time.at(0)
@@ -177,7 +194,7 @@ module SoftLayer
     end
 
     ##
-    # The virtual servers (aka. CCIs or Virtual_Guests) associated with the
+    # Retrieve the virtual servers (aka. CCIs or Virtual_Guests) associated with the
     # account. Unless you force these to update, they will be refreshed every
     # five minutes.
     # :call-seq:

--- a/lib/softlayer/AccountPassword.rb
+++ b/lib/softlayer/AccountPassword.rb
@@ -32,6 +32,8 @@ module SoftLayer
 
     ##
     # A description of the use for the account username/password combination.
+    # :call-seq:
+    #   description(force_update=false)
     sl_dynamic_attr :description do |resource|
       resource.should_update? do
         #only retrieved once per instance

--- a/lib/softlayer/BareMetalServer.rb
+++ b/lib/softlayer/BareMetalServer.rb
@@ -9,7 +9,7 @@
 module SoftLayer
   #
   # This class represents a Bare Metal Server, a hardware server in contrast to a virtual machine,
-  # in the SoftLayer Environment. It corresponds rougly to the +SoftLayer_Hardware+ and
+  # in the SoftLayer Environment. It corresponds roughly to the +SoftLayer_Hardware+ and
   # +SoftLayer_Hardware_Server+ services in the SoftLayer API
   #
   # http://sldn.softlayer.com/reference/datatypes/SoftLayer_Hardware
@@ -23,7 +23,7 @@ module SoftLayer
     # a Bare Metal Instance is physical, hardware server that is is provisioned to
     # match a profile with characteristics similar to a Virtual Server
     #
-    # This is an important distincition in rare cases, like cancelling the server.
+    # This is an important distinction in rare cases, like cancelling the server.
     #
     def bare_metal_instance?
       if has_sl_property?(:bareMetalInstanceFlag)
@@ -65,7 +65,7 @@ module SoftLayer
     # Returns the typical Service used to work with this Server
     # For Bare Metal Servers that is +SoftLayer_Hardware+ though in some special cases
     # you may have to use +SoftLayer_Hardware_Server+ as a type or service.  That
-    # service object is available thorugh the hardware_server_service method
+    # service object is available through the hardware_server_service method
     def service
       return softlayer_client[:Hardware_Server].object_with_id(self.id)
     end
@@ -146,7 +146,7 @@ module SoftLayer
     end
 
     ##
-    # Retrive the bare metal server with the given server ID from the
+    # Retrieve the bare metal server with the given server ID from the
     # SoftLayer API
     #
     # The options parameter should contain:

--- a/lib/softlayer/BareMetalServerOrder.rb
+++ b/lib/softlayer/BareMetalServerOrder.rb
@@ -93,7 +93,7 @@ module SoftLayer
     attr_accessor :max_port_speed
 
     ##
-    # Create a new order that works thorugh the given client connection
+    # Create a new order that works through the given client connection
     def initialize (client = nil)
       @softlayer_client = client || Client.default_client
       raise "#{__method__} requires a client but none was given and Client::default_client is not set" if !@softlayer_client
@@ -195,7 +195,7 @@ module SoftLayer
     end
 
     ##
-    # Returns a list of the valid :os_refrence_codes
+    # Returns a list of the valid :os_reference_codes
     def self.os_reference_code_options(client = nil)
       create_object_options(client)['operatingSystems'].collect { |os_spec| os_spec['template']['operatingSystemReferenceCode'] }.uniq.sort!
     end

--- a/lib/softlayer/BareMetalServerOrder_Package.rb
+++ b/lib/softlayer/BareMetalServerOrder_Package.rb
@@ -49,7 +49,7 @@ module SoftLayer
     # that is the +id+ of a +SoftLayer_Product_Item_Price+. Instances of the ProductConfigurationOption
     # class behave this way.
     #
-    # At a minimum, the configuation_options should include entries for each of the categories
+    # At a minimum, the configuration_options should include entries for each of the categories
     # required by the package (i.e. those returned from ProductPackage#required_categories)
     attr_accessor :configuration_options
 

--- a/lib/softlayer/BareMetalServerOrder_Package.rb
+++ b/lib/softlayer/BareMetalServerOrder_Package.rb
@@ -42,7 +42,7 @@ module SoftLayer
     # The domain of the server being created (i.e. 'softlayer.com' is the domain of sldn.softlayer.com)
     attr_accessor :domain
 
-    # The value of this property should be a hash. The keys of the hash are ProdcutItemCategory
+    # The value of this property should be a hash. The keys of the hash are ProductItemCategory
     # codes (like 'os' and 'ram') while the values may be Integers or Objects. The Integer values
     # should be the +id+ of a +SoftLayer_Product_Item_Price+ representing the configuration option
     # chosen for that category. Objects must respond to the +price_id+ message and return an integer

--- a/lib/softlayer/Client.rb
+++ b/lib/softlayer/Client.rb
@@ -6,7 +6,7 @@
 
 module SoftLayer
   # A client is responsible for storing authentication information for API calls and
-  # it serves as a centeral repository for the Service instances that call into the
+  # it serves as a central repository for the Service instances that call into the
   # network API.
   #
   # When you create a client, you pass in hash arguments specifying how the client
@@ -21,16 +21,16 @@ module SoftLayer
   # class to provide the missing information.  Please see that class for details.
   #
   class Client
-    # A username passed as authentication for each request. Cannot be emtpy or nil.
+    # A username passed as authentication for each request. Cannot be empty or nil.
     attr_reader :username
 
-    # An API key passed as part of the authentication of each request. Cannot be emtpy or nil.
+    # An API key passed as part of the authentication of each request. Cannot be empty or nil.
     attr_reader :api_key
 
-    # The base URL for requests that are passed to the server. Cannot be emtpy or nil.
+    # The base URL for requests that are passed to the server. Cannot be empty or nil.
     attr_reader :endpoint_url
 
-    # A string passsed as the value for the User-Agent header when requests are sent to SoftLayer API.
+    # A string passed as the value for the User-Agent header when requests are sent to SoftLayer API.
     attr_accessor :user_agent
 
     # An integer value (in seconds). The number of seconds to wait for HTTP requests to the network API
@@ -63,7 +63,7 @@ module SoftLayer
     # Clients are built with a number of settings:
     # * <b>+:username+</b> - The username of the account you wish to access through the API
     # * <b>+:api_key+</b> - The API key used to authenticate the user with the API
-    # * <b>+:enpoint_url+</b> - The API endpoint the client should connect to.  This defaults to API_PUBLIC_ENDPOINT
+    # * <b>+:endpoint_url+</b> - The API endpoint the client should connect to.  This defaults to API_PUBLIC_ENDPOINT
     # * <b>+:user_agent+</b> - A string that is passed along as the user agent when the client sends requests to the server
     # * <b>+:timeout+</b> - An integer number of seconds to wait until network requests time out.  Corresponds to the network_timeout property of the client
     #
@@ -92,7 +92,7 @@ module SoftLayer
 
       raise "A SoftLayer Client requires a username" if !@username || @username.empty?
       raise "A SoftLayer Client requires an api_key" if !@api_key || @api_key.empty?
-      raise "A SoftLayer Clietn requires an enpoint URL" if !@endpoint_url || @endpoint_url.empty?
+      raise "A SoftLayer Client requires an endpoint URL" if !@endpoint_url || @endpoint_url.empty?
     end
 
     # return a hash of the authentication headers for the client

--- a/lib/softlayer/Config.rb
+++ b/lib/softlayer/Config.rb
@@ -11,7 +11,7 @@ module SoftLayer
   # The SoftLayer Config class is responsible for providing the key information
   # the library needs to communicate with the network SoftLayer API. Those three crucial
   # pieces of information are the Username, the API Key, and the endpoint_url. This information
-  # is collected in a hash with the keys `:username`, `:api_key`, and `:endpoint_url` repsectively.
+  # is collected in a hash with the keys `:username`, `:api_key`, and `:endpoint_url` respectively.
   #
   # The routine used to retrieve this information from a Config object is Config.client_settings
   #
@@ -43,7 +43,7 @@ module SoftLayer
   # = Environment Variables
   #
   # The config class will search the environment variables SL_USERNAME and SL_API_KEY for
-  # the username and API key respectively. The endpoint_url may not be set thorugh
+  # the username and API key respectively. The endpoint_url may not be set through
   # environment variables.
   #
   # = Global Variables

--- a/lib/softlayer/Datacenter.rb
+++ b/lib/softlayer/Datacenter.rb
@@ -38,7 +38,7 @@ module SoftLayer
     # Return a list of all the datacenters
     #
     # If the client parameter is not provided, the routine
-    # will try to use Client::defult_client.  If no client
+    # will try to use Client::default_client.  If no client
     # can be found, the routine will raise an exception
     #
     # This routine will only retrieve the list of datacenters from

--- a/lib/softlayer/Datacenter.rb
+++ b/lib/softlayer/Datacenter.rb
@@ -17,7 +17,15 @@ module SoftLayer
   # represent.
 
   class Datacenter < SoftLayer::ModelBase
+
+    ##
+    # :attr_reader:
+    # A short location description
     sl_attr :name
+
+    ##
+    # :attr_reader: long_name
+    # A longer location description
     sl_attr :long_name, "longName"
 
     ##

--- a/lib/softlayer/DynamicAttribute.rb
+++ b/lib/softlayer/DynamicAttribute.rb
@@ -7,7 +7,7 @@
 module SoftLayer
 
   ##
-  # This module is inteneded to be used by classes in the SoftLayer
+  # This module is intended to be used by classes in the SoftLayer
   # object model. It creates a small DSL for creating attributes
   # that update themselves dynamically (usually by making requests
   # to the SoftLayer API)

--- a/lib/softlayer/ImageTemplate.rb
+++ b/lib/softlayer/ImageTemplate.rb
@@ -210,7 +210,7 @@ module SoftLayer
     #
     # Additional options that may be provided:
     # * <b>+:name+</b>      (string/array) - Return templates with the given name
-    # * <b>+:global_id+</b> (string/array) - Return templates with the given global identfier
+    # * <b>+:global_id+</b> (string/array) - Return templates with the given global identifier
     # * <b>+:tags+</b>      (string/array) - Return templates with the tags
     def self.find_private_templates(options_hash = {})
       softlayer_client = options_hash[:client] || Client.default_client
@@ -267,7 +267,7 @@ module SoftLayer
     #
     # Additional options that may be provided:
     # * <b>+:name+</b>      (string/array) - Return templates with the given name
-    # * <b>+:global_id+</b> (string/array) - Return templates with the given global identfier
+    # * <b>+:global_id+</b> (string/array) - Return templates with the given global identifier
     # * <b>+:tags+</b>      (string/array) - Return templates with the tags
     def self.find_public_templates(options_hash = {})
       softlayer_client = options_hash[:client] || Client.default_client

--- a/lib/softlayer/ImageTemplate.rb
+++ b/lib/softlayer/ImageTemplate.rb
@@ -23,12 +23,12 @@ module SoftLayer
     sl_attr :name
 
     ##
-    # :attr_reader:
+    # :attr_reader: notes
     # The notes, if any, that are attached to the template. Can be nil.
     sl_attr :notes, "note"
 
     ##
-    # :attr_reader:
+    # :attr_reader: global_id
     # The universally unique identifier (if any) for the template. Can be nil.
     sl_attr :global_id, 'globalIdentifier'
 

--- a/lib/softlayer/ImageTemplate.rb
+++ b/lib/softlayer/ImageTemplate.rb
@@ -9,7 +9,7 @@ module SoftLayer
   ##
   # A Virtual Server Image Template.
   #
-  # This class rougly corresponds to the unwieldily named
+  # This class roughly corresponds to the unwieldy named
   # +SoftLayer_Virtual_Guest_Block_Device_Template_Group+
   # service:
   #
@@ -23,12 +23,12 @@ module SoftLayer
     sl_attr :name
 
     ##
-    # :attr_reader:
+    # :attr_reader: notes
     # The notes, if any, that are attached to the template. Can be nil.
     sl_attr :notes, "note"
 
     ##
-    # :attr_reader:
+    # :attr_reader: global_id
     # The universally unique identifier (if any) for the template. Can be nil.
     sl_attr :global_id, 'globalIdentifier'
 
@@ -91,7 +91,7 @@ module SoftLayer
     # appear in this array! The list given must be comprehensive.
     #
     # The available_datacenters call returns a list of the values that are valid
-    # whithin this array.
+    # within this array.
     def datacenters=(datacenters_array)
       datacenter_data = datacenters_array.collect do |datacenter|
         { "id" => datacenter.id }
@@ -160,7 +160,7 @@ module SoftLayer
     end
 
     ##
-    # Repeatedly poll the netwokr API until transactions related to this image
+    # Repeatedly poll the network API until transactions related to this image
     # template are finished
     #
     # A template is not 'ready' until all the transactions on the template
@@ -313,7 +313,7 @@ module SoftLayer
     end
 
     ##
-    # Retrive the Image Template with the given ID
+    # Retrieve the Image Template with the given ID
     # (Note! This is the service ID, not the globalIdentifier!)
     #
     # The options parameter should contain:

--- a/lib/softlayer/ImageTemplate.rb
+++ b/lib/softlayer/ImageTemplate.rb
@@ -9,7 +9,7 @@ module SoftLayer
   ##
   # A Virtual Server Image Template.
   #
-  # This class rougly corresponds to the unwieldily named
+  # This class roughly corresponds to the unwieldy named
   # +SoftLayer_Virtual_Guest_Block_Device_Template_Group+
   # service:
   #
@@ -91,7 +91,7 @@ module SoftLayer
     # appear in this array! The list given must be comprehensive.
     #
     # The available_datacenters call returns a list of the values that are valid
-    # whithin this array.
+    # within this array.
     def datacenters=(datacenters_array)
       datacenter_data = datacenters_array.collect do |datacenter|
         { "id" => datacenter.id }
@@ -160,7 +160,7 @@ module SoftLayer
     end
 
     ##
-    # Repeatedly poll the netwokr API until transactions related to this image
+    # Repeatedly poll the network API until transactions related to this image
     # template are finished
     #
     # A template is not 'ready' until all the transactions on the template
@@ -210,7 +210,7 @@ module SoftLayer
     #
     # Additional options that may be provided:
     # * <b>+:name+</b> (string) - Return templates with the given name
-    # * <b>+:global_id+</b> (string) - Return templates with the given global identfier
+    # * <b>+:global_id+</b> (string) - Return templates with the given global identifier
     def self.find_private_templates(options_hash = {})
       softlayer_client = options_hash[:client] || Client.default_client
       raise "#{__method__} requires a client but none was given and Client::default_client is not set" if !softlayer_client
@@ -276,7 +276,7 @@ module SoftLayer
     #
     # Additional options that may be provided:
     # * <b>+:name+</b> (string) - Return templates with the given name
-    # * <b>+:global_id+</b> (string) - Return templates with the given global identfier
+    # * <b>+:global_id+</b> (string) - Return templates with the given global identifier
     def self.find_public_templates(options_hash = {})
       softlayer_client = options_hash[:client] || Client.default_client
       raise "#{__method__} requires a client but none was given and Client::default_client is not set" if !softlayer_client
@@ -331,7 +331,7 @@ module SoftLayer
     end
 
     ##
-    # Retrive the Image Template with the given ID
+    # Retrieve the Image Template with the given ID
     # (Note! This is the service ID, not the globalIdentifier!)
     #
     # The options parameter should contain:

--- a/lib/softlayer/ModelBase.rb
+++ b/lib/softlayer/ModelBase.rb
@@ -69,7 +69,7 @@ module SoftLayer
     ##
     # Returns the value of of the given property as stored in the
     # softlayer_hash. This gives you access to the low-level, raw
-    # properties that underly this model object.  The need for this
+    # properties that underlie this model object.  The need for this
     # is not uncommon, but using this method should still be done
     # with deliberation.
     def [](softlayer_property)
@@ -107,7 +107,7 @@ module SoftLayer
 
     ##
     # Subclasses should implement this method as part of enabling the
-    # refresh_details fuctionality The implementation should make a request
+    # refresh_details functionality The implementation should make a request
     # to the SoftLayer API and retrieve an up-to-date SoftLayer hash
     # representation of this object. That hash should be the return value
     # of this routine.

--- a/lib/softlayer/NetworkMessageDelivery.rb
+++ b/lib/softlayer/NetworkMessageDelivery.rb
@@ -17,12 +17,12 @@ module SoftLayer
     include ::SoftLayer::DynamicAttribute
 
     ##
-    # :attr_reader:
+    # :attr_reader: created
     # The date this username/password pair was created.
     sl_attr :created,  'createDate'
 
     ##
-    # :attr_reader:
+    # :attr_reader: modified
     # The date of the last modification to this username/password pair.
     sl_attr :modified, 'modifyDate'
 

--- a/lib/softlayer/NetworkMessageDelivery.rb
+++ b/lib/softlayer/NetworkMessageDelivery.rb
@@ -37,7 +37,9 @@ module SoftLayer
     sl_attr :username
 
     ##
-    # The message delivery type description of a network message delivery account.
+    # Retrieve the message delivery type description of a network message delivery account.
+    # :call-seq:
+    #   description(force_update=false)
     sl_dynamic_attr :description do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -51,7 +53,9 @@ module SoftLayer
     end
 
     ##
-    # The message delivery type name of a network message delivery account.
+    # Retrieve the message delivery type name of a network message delivery account.
+    # :call-seq:
+    #   name(force_update=false)
     sl_dynamic_attr :name do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -65,7 +69,9 @@ module SoftLayer
     end
 
     ##
-    # The vendor name for a network message delivery account.
+    # Retrieve the vendor name for a network message delivery account.
+    # :call-seq:
+    #   vendor(force_update=false)
     sl_dynamic_attr :vendor do |resource|
       resource.should_update? do
         #only retrieved once per instance

--- a/lib/softlayer/NetworkService.rb
+++ b/lib/softlayer/NetworkService.rb
@@ -21,17 +21,17 @@ module SoftLayer
     sl_attr :name
 
     ##
-    # :attr_reader:
+    # :attr_reader: private_ip
     # The backend IP address for this resource
     sl_attr :private_ip,   'backendIpAddress'
 
     ##
-    # :attr_reader:
+    # :attr_reader: public_ip
     # The frontend IP address for this resource
     sl_attr :public_ip,    'frontendIpAddress'
 
     ##
-    # :attr_reader:
+    # :attr_reader: ssh_username
     # The ssh username of for this resource
     sl_attr :ssh_username, 'sshUsername'
 

--- a/lib/softlayer/NetworkService.rb
+++ b/lib/softlayer/NetworkService.rb
@@ -36,7 +36,9 @@ module SoftLayer
     sl_attr :ssh_username, 'sshUsername'
 
     ##
-    # Returns the datacenter that this network service resource is available in
+    # Retrieve the datacenter that this network service resource is available in
+    # :call-seq:
+    #   datacenter(force_update=false)
     sl_dynamic_attr :datacenter do |resource|
       resource.should_update? do
         #only retrieved once per instance

--- a/lib/softlayer/NetworkStorage.rb
+++ b/lib/softlayer/NetworkStorage.rb
@@ -55,7 +55,9 @@ module SoftLayer
     sl_attr :username
 
     ##
-    # Other usernames and passwords associated with a Storage volume.
+    # Retrieve other usernames and passwords associated with a Storage volume.
+    # :call-seq:
+    #   account_password(force_update=false)
     sl_dynamic_attr :account_password do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -70,6 +72,8 @@ module SoftLayer
 
     ##
     # A Storage volume's access credentials.
+    # :call-seq:
+    #   credentials(force_update=false)
     sl_dynamic_attr :credentials do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -83,6 +87,8 @@ module SoftLayer
 
     ##
     # The network resource a Storage service is connected to.
+    # :call-seq:
+    #   service_resource(force_update=false)
     sl_dynamic_attr :service_resource do |resource|
       resource.should_update? do
         #only retrieved once per instance

--- a/lib/softlayer/NetworkStorage.rb
+++ b/lib/softlayer/NetworkStorage.rb
@@ -16,12 +16,12 @@ module SoftLayer
     include ::SoftLayer::DynamicAttribute
 
     ##
-    # :attr_reader:
+    # :attr_reader: capacity
     # A Storage account's capacity, measured in gigabytes.
     sl_attr :capacity,   'capacityGb'
 
     ##
-    # :attr_reader:
+    # :attr_reader: created
     # The date a network storage volume was created.
     sl_attr :created,    'createDate'
 
@@ -38,12 +38,12 @@ module SoftLayer
     sl_attr :password
 
     ##
-    # :attr_reader:
+    # :attr_reader: type
     # A Storage account's type.
     sl_attr :type,       'nasType'
 
     ##
-    # :attr_reader:
+    # :attr_reader: upgradable
     # This flag indicates whether this storage type is upgradable or not.
     sl_attr :upgradable, 'upgradableFlag'
 

--- a/lib/softlayer/NetworkStorageAllowedHost.rb
+++ b/lib/softlayer/NetworkStorageAllowedHost.rb
@@ -15,7 +15,9 @@ module SoftLayer
     sl_attr :name
 
     ##
-    # The NetworkStorageGroup instances assigned to this host
+    # Retrieve the NetworkStorageGroup instances assigned to this host
+    # :call-seq:
+    #   assigned_groups(force_update=false)
     sl_dynamic_attr :assigned_groups do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -29,7 +31,9 @@ module SoftLayer
     end
 
     ##
-    # The NetworkStorage instances assigned to this host
+    # Retrieve the NetworkStorage instances assigned to this host
+    # :call-seq:
+    #   assigned_volumes(force_update=false)
     sl_dynamic_attr :assigned_volumes do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -43,7 +47,9 @@ module SoftLayer
     end
 
     ##
-    # The NetworkStorageCredential instance used to access NetworkStorage for this host
+    # Retrieve the NetworkStorageCredential instance used to access NetworkStorage for this host
+    # :call-seq:
+    #   credential(force_update=false)
     sl_dynamic_attr :credential do |resource|
       resource.should_update? do
         #only retrieved once per instance

--- a/lib/softlayer/NetworkStorageCredential.rb
+++ b/lib/softlayer/NetworkStorageCredential.rb
@@ -17,12 +17,12 @@ module SoftLayer
     include ::SoftLayer::DynamicAttribute
 
     ##
-    # :attr_reader:
+    # :attr_reader: created
     # This is the data that the record was created in the table.
     sl_attr :created,  'createDate'
 
     ##
-    # :attr_reader:
+    # :attr_reader: modified
     # This is the date that the record was last updated in the table.
     sl_attr :modified, 'modifyDate'
 

--- a/lib/softlayer/NetworkStorageGroup.rb
+++ b/lib/softlayer/NetworkStorageGroup.rb
@@ -25,7 +25,9 @@ module SoftLayer
     sl_attr :modified, 'modifyDate'
 
     ##
-    # The SoftLayer_Account which owns this group.
+    # Retrieve the SoftLayer_Account which owns this group.
+    # :call-seq:
+    #   account(force_update=false)
     sl_dynamic_attr :account do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -39,7 +41,9 @@ module SoftLayer
     end
 
     ##
-    # The allowed hosts list for this group.
+    # Retrieve the allowed hosts list for this group.
+    # :call-seq:
+    #   allowed_hosts(force_update=false)
     sl_dynamic_attr :allowed_hosts do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -53,7 +57,9 @@ module SoftLayer
     end
 
     ##
-    # The network storage volumes this group is attached to.
+    # Retrieve the network storage volumes this group is attached to.
+    # :call-seq:
+    #   attached_volumes(force_update=false)
     sl_dynamic_attr :attached_volumes do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -67,7 +73,9 @@ module SoftLayer
     end
 
     ##
-    # The IP address for for SoftLayer_Network_Storage_Allowed_Host objects within this group.
+    # Retrieve the IP address for for SoftLayer_Network_Storage_Allowed_Host objects within this group.
+    # :call-seq:
+    #   ip_address(force_update=false)
     sl_dynamic_attr :ip_address do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -81,7 +89,10 @@ module SoftLayer
     end
 
     ##
-    # The description of the SoftLayer_Network_Storage_OS_Type Operating System designation that this group was created for.
+    # Retrieve the description of the SoftLayer_Network_Storage_OS_Type 
+    # Operating System designation that this group was created for.
+    # :call-seq:
+    #   os_description(force_update=false)
     sl_dynamic_attr :os_description do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -95,7 +106,10 @@ module SoftLayer
     end
 
     ##
-    # The name of the SoftLayer_Network_Storage_OS_Type Operating System designation that this group was created for.
+    # Retrieve the name of the SoftLayer_Network_Storage_OS_Type 
+    # Operating System designation that this group was created for.
+    # :call-seq:
+    #   os_name(force_update=false)
     sl_dynamic_attr :os_name do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -109,7 +123,9 @@ module SoftLayer
     end
 
     ##
-    # The network resource this group is created on.
+    # Retrieve the network resource this group is created on.
+    # :call-seq:
+    #   service_resource(force_update=false)
     sl_dynamic_attr :service_resource do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -123,7 +139,9 @@ module SoftLayer
     end
 
     ##
-    # The name of the SoftLayer_Network_Storage_Group_Type which describes this group.
+    # Retrieve the name of the SoftLayer_Network_Storage_Group_Type which describes this group.
+    # :call-seq:
+    #   type(force_update=false)
     sl_dynamic_attr :type do |resource|
       resource.should_update? do
         #only retrieved once per instance

--- a/lib/softlayer/NetworkStorageGroup.rb
+++ b/lib/softlayer/NetworkStorageGroup.rb
@@ -15,12 +15,12 @@ module SoftLayer
     sl_attr :alias
 
     ##
-    # :attr_reader:
+    # :attr_reader: created
     # The date this group was created.
     sl_attr :created, 'createDate'
 
     ##
-    # :attr_reader:
+    # :attr_reader: modified
     # The date this group was modified.
     sl_attr :modified, 'modifyDate'
 

--- a/lib/softlayer/NetworkStorageGroup.rb
+++ b/lib/softlayer/NetworkStorageGroup.rb
@@ -81,7 +81,7 @@ module SoftLayer
     end
 
     ##
-    # The description of theSoftLayer_Network_Storage_OS_Type Operating System designation that this group was created for.
+    # The description of the SoftLayer_Network_Storage_OS_Type Operating System designation that this group was created for.
     sl_dynamic_attr :os_description do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -95,7 +95,7 @@ module SoftLayer
     end
 
     ##
-    # The name of theSoftLayer_Network_Storage_OS_Type Operating System designation that this group was created for.
+    # The name of the SoftLayer_Network_Storage_OS_Type Operating System designation that this group was created for.
     sl_dynamic_attr :os_name do |resource|
       resource.should_update? do
         #only retrieved once per instance

--- a/lib/softlayer/ObjectFilter.rb
+++ b/lib/softlayer/ObjectFilter.rb
@@ -178,7 +178,7 @@ module SoftLayer
       }
     end
 
-    # Matches when key path value is equal to one of the given values in the Enumarable
+    # Matches when key path value is equal to one of the given values in the Enumerable
     def self.is_contained_by(value)
       raise "Expected an Enumerable value with a list of acceptable values that can be converted to strings" unless value.kind_of?(Enumerable)
 
@@ -193,7 +193,7 @@ module SoftLayer
       }
     end
 
-    # Matches when key path value is not equal to one of the given values in the Enumarable
+    # Matches when key path value is not equal to one of the given values in the Enumerable
     def self.is_not_contained_by(value)
       raise "Expected an Enumerable value with a list of acceptable values that can be converted to strings" unless value.kind_of?(Enumerable)
 

--- a/lib/softlayer/ObjectFilter.rb
+++ b/lib/softlayer/ObjectFilter.rb
@@ -115,7 +115,7 @@ module SoftLayer
   # The ObjectFilterDefinitionContext defines a bunch of methods
   # that allow the property conditions of an object filter to
   # be defined in a "pretty" way. Each method returns a block
-  # (a lambda, a proc) that, when called and pased the tail property
+  # (a lambda, a proc) that, when called and passed the tail property
   # of a property chain will generate a fragment of an object filter
   # asking that that property match the given conditions.
   #
@@ -153,7 +153,7 @@ module SoftLayer
       filter_criteria('$=', value)
     end
 
-    # Maches the given value in a case-insensitive way
+    # Matches the given value in a case-insensitive way
     def self.matches_ignoring_case(value)
       filter_criteria('_=', value)
     end

--- a/lib/softlayer/ObjectMaskParser.rb
+++ b/lib/softlayer/ObjectMaskParser.rb
@@ -138,4 +138,4 @@ module SoftLayer
     end
 
   end
-end # Module SoftLaye
+end # Module SoftLayer

--- a/lib/softlayer/ProductItemCategory.rb
+++ b/lib/softlayer/ProductItemCategory.rb
@@ -62,6 +62,10 @@ module SoftLayer
     # The name of a category is a friendly, readable string
     sl_attr :name
 
+    ##
+    # Retrieve the product item configuration information
+    # :call-seq:
+    #   configuration_options(force_update=false)
     sl_dynamic_attr :configuration_options do |config_opts|
       config_opts.should_update? do
         # only retrieved once per instance

--- a/lib/softlayer/ProductItemCategory.rb
+++ b/lib/softlayer/ProductItemCategory.rb
@@ -32,7 +32,7 @@ module SoftLayer
       self.setupFee                   = price_item_data['setupFee']                   ? price_item_data['setupFee'].to_f              : 0.0
     end
 
-    # returns true if the configurtion option has no fees associated with it.
+    # returns true if the configuration option has no fees associated with it.
     def free?
       self.setupFee == 0 && self.laborFee == 0 && self.oneTimeFee == 0 && self.recurringFee == 0 && self.hourlyRecurringFee == 0
     end
@@ -46,7 +46,7 @@ module SoftLayer
   # of a ProductPackage object. There should not be a need to create instances
   # of this class directly.
   #
-  # This class rougly represents entities in the +SoftLayer_Product_Item_Category+
+  # This class roughly represents entities in the +SoftLayer_Product_Item_Category+
   # service.
   class ProductItemCategory < ModelBase
     include ::SoftLayer::DynamicAttribute

--- a/lib/softlayer/ProductPackage.rb
+++ b/lib/softlayer/ProductPackage.rb
@@ -48,8 +48,9 @@ module SoftLayer
     sl_attr :available_locations, 'availableLocations'
 
     ##
-    # The set of product categories needed to make an order for this product package.
-    #
+    # Retrieve the set of product categories needed to make an order for this product package.
+    # :call-seq:
+    #   configuration(force_update=false)
     sl_dynamic_attr :configuration do |resource|
       resource.should_update? do
         # only retrieved once per instance
@@ -98,8 +99,9 @@ module SoftLayer
     end # configuration
 
     ##
-    # The full set of product categories contained in the package
-    #
+    # Retrieve the full set of product categories contained in the package
+    # :call-seq:
+    #   categories(force_update=false)
     sl_dynamic_attr :categories do |resource|
       resource.should_update? do
         @categories == nil

--- a/lib/softlayer/ProductPackage.rb
+++ b/lib/softlayer/ProductPackage.rb
@@ -38,10 +38,12 @@ module SoftLayer
     include ::SoftLayer::DynamicAttribute
 
     ##
+    # :attr_reader:
     # A friendly, readable name for the package
     sl_attr :name
 
     ##
+    # :attr_reader: available_locations
     # The list of locations where this product package is available.
     sl_attr :available_locations, 'availableLocations'
 

--- a/lib/softlayer/ProductPackage.rb
+++ b/lib/softlayer/ProductPackage.rb
@@ -111,7 +111,7 @@ module SoftLayer
         # that are required)
         self.configuration
 
-        # return the value constructed by the configuraiton
+        # return the value constructed by the configuration
         @categories
       end
     end

--- a/lib/softlayer/Server.rb
+++ b/lib/softlayer/Server.rb
@@ -53,6 +53,10 @@ module SoftLayer
     # Notes about these server (for use by the customer)
     sl_attr :notes
 
+    ##
+    # Retrieve the primary network component
+    # :call-seq:
+    #   primary_network_component(force_update=false)
     sl_dynamic_attr :primary_network_component do |primary_component|
       primary_component.should_update? do
         return @primary_network_component == nil
@@ -65,8 +69,9 @@ module SoftLayer
     end
 
     ##
-    # :attr_reader:
-    # All software installed on current server
+    # Retrieve all software installed on current server
+    # :call-seq:
+    #   software(force_update=false)
     sl_dynamic_attr :software do |software|
       software.should_update? do
         @software == nil

--- a/lib/softlayer/Server.rb
+++ b/lib/softlayer/Server.rb
@@ -39,12 +39,12 @@ module SoftLayer
     sl_attr :datacenter
 
     ##
-    # :attr_reader:
+    # :attr_reader: primary_public_ip
     # The IP address of the primary public interface for the server
     sl_attr :primary_public_ip, "primaryIpAddress"
 
     ##
-    # :attr_reader:
+    # :attr_reader: primary_private_ip
     # The IP address of the primary private interface for the server
     sl_attr :primary_private_ip, "primaryBackendIpAddress"
 

--- a/lib/softlayer/Server.rb
+++ b/lib/softlayer/Server.rb
@@ -97,7 +97,7 @@ module SoftLayer
     # Reboot the server.  This action is taken immediately.
     # Servers can be rebooted in three different ways:
     # :default_reboot - (Try soft, then hard) Attempts to reboot a server using the :os_reboot technique then, if that is not successful, tries the :power_cycle method
-    # :os_reboot - (aka. soft rebot) instructs the server's host operating system to reboot
+    # :os_reboot - (aka. soft reboot) instructs the server's host operating system to reboot
     # :power_cycle - (aka. hard reboot) The actual (for hardware) or metaphorical (for virtual servers) equivalent to pulling the plug on the server then plugging it back in.
     def reboot!(reboot_technique = :default_reboot)
       case reboot_technique

--- a/lib/softlayer/ServerFirewall.rb
+++ b/lib/softlayer/ServerFirewall.rb
@@ -12,7 +12,7 @@ module SoftLayer
   #
   # This is also called a "Shared Firewall" in some documentation.
   #
-  # Instances of this class rougly correspond to instances of the
+  # Instances of this class roughly correspond to instances of the
   # SoftLayer_Network_Component_Firewall service entity.
   #
 	class ServerFirewall < SoftLayer::ModelBase

--- a/lib/softlayer/ServerFirewall.rb
+++ b/lib/softlayer/ServerFirewall.rb
@@ -27,11 +27,12 @@ module SoftLayer
     sl_attr :status
 
     ##
-    # :attr_reader:
-    # The firewall rules assigned to this firewall. These rules will
+    # Retrieve the firewall rules assigned to this firewall. These rules will
     # be read from the network API every time you ask for the value
     # of this property. To change the rules on the server use the
     # asymmetric method change_rules!
+    # :call-seq:
+    #   rules(force_update=false)
     sl_dynamic_attr :rules do |firewall_rules|
       firewall_rules.should_update? do
         # firewall rules update every time you ask for them.
@@ -56,10 +57,10 @@ module SoftLayer
     end
 
     ##
-    # :attr_reader:
-    # The server that this firewall is attached to. The result may be
+    # Retrieve the server that this firewall is attached to. The result may be
     # either a bare metal or virtual server.
-    #
+    # :call-seq:
+    #   protected_server(force_update=false)
     sl_dynamic_attr :protected_server do |protected_server|
       protected_server.should_update? do
         @protected_server == nil

--- a/lib/softlayer/ServerFirewall.rb
+++ b/lib/softlayer/ServerFirewall.rb
@@ -129,7 +129,7 @@ module SoftLayer
     # *NOTE!* The rules themselves have an "orderValue" property.
     # It is this property, and *not* the order that the rules are
     # found in the rules_data array, which will determine in which
-    # order the firewall applies it's rules to incomming traffic.
+    # order the firewall applies it's rules to incoming traffic.
     #
     # *NOTE!* Changes to the rules are not applied immediately
     # on the server side. Instead, they are enqueued by the

--- a/lib/softlayer/Service.rb
+++ b/lib/softlayer/Service.rb
@@ -70,7 +70,7 @@ module SoftLayer
   #     => {... lots of information here representing the list of open tickets ...}
   #
   class Service
-    # The name of the service that this object calls. Cannot be emtpy or nil.
+    # The name of the service that this object calls. Cannot be empty or nil.
     attr_reader :service_name
     attr_reader :client
 

--- a/lib/softlayer/Software.rb
+++ b/lib/softlayer/Software.rb
@@ -110,7 +110,7 @@ module SoftLayer
     end
 
     ##
-    # Returns whether or not one of the Software Passowrd instances pertains to the specified user
+    # Returns whether or not one of the Software Password instances pertains to the specified user
     #
     def has_user_password?(username)
       self.passwords.map { |sw_pw| sw_pw.username }.include?(username)

--- a/lib/softlayer/Software.rb
+++ b/lib/softlayer/Software.rb
@@ -16,12 +16,12 @@ module SoftLayer
     include ::SoftLayer::DynamicAttribute
 
     ##
-    # :attr_reader:
+    # :attr_reader: manufacturer_activation_code
     # The manufacturer code that is needed to activate a license.
     sl_attr :manufacturer_activation_code, 'manufacturerActivationCode'
 
     ##
-    # :attr_reader:
+    # :attr_reader: manufacturer_license_key
     # A license key for this specific installation of software, if it is needed.
     sl_attr :manufacturer_license_key,     'manufacturerLicenseInstance'
 

--- a/lib/softlayer/Software.rb
+++ b/lib/softlayer/Software.rb
@@ -26,7 +26,9 @@ module SoftLayer
     sl_attr :manufacturer_license_key,     'manufacturerLicenseInstance'
 
     ##
-    # The manufacturer, name and version of a piece of software.
+    # Retrieve the manufacturer, name and version of a piece of software.
+    # :call-seq:
+    #   description(force_update=false)
     sl_dynamic_attr :description do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -40,7 +42,9 @@ module SoftLayer
     end
 
     ##
-    # The name of this specific piece of software. 
+    # Retrieve the name of this specific piece of software. 
+    # :call-seq:
+    #   name(force_update=false)
     sl_dynamic_attr :name do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -54,7 +58,9 @@ module SoftLayer
     end
 
     ##
-    # Username/Password pairs used for access to this Software Installation.
+    # Retrieve the Username/Password pairs used for access to this Software Installation.
+    # :call-seq:
+    #   passwords(force_update=false)
     sl_dynamic_attr :passwords do |resource|
       resource.should_update? do
         #only retrieved once per instance

--- a/lib/softlayer/SoftwarePassword.rb
+++ b/lib/softlayer/SoftwarePassword.rb
@@ -16,12 +16,12 @@ module SoftLayer
     include ::SoftLayer::DynamicAttribute
     
     ##
-    # :attr_reader:
+    # :attr_reader: created
     # The date this username/password pair was created.
     sl_attr :created, 'createDate'
 
     ##
-    # :attr_reader:
+    # :attr_reader: modified
     # The date of the last modification to this username/password pair.
     sl_attr :modified, 'modifyDate'
 

--- a/lib/softlayer/UserCustomer.rb
+++ b/lib/softlayer/UserCustomer.rb
@@ -71,8 +71,10 @@ module SoftLayer
     sl_attr :username
 
     ##
-    # A portal user's additional email addresses.
+    # Retrieve a portal user's additional email addresses.
     # These email addresses are contacted when updates are made to support tickets.
+    # :call-seq:
+    #   additional_emails(force_update=false)
     sl_dynamic_attr :additional_emails do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -86,8 +88,10 @@ module SoftLayer
     end
 
     ##
-    # A portal user's API Authentication keys.
+    # Retrieve a portal user's API Authentication keys.
     # There is a max limit of two API keys per user.
+    # :call-seq:
+    #   api_authentication_keys(force_update=false)
     sl_dynamic_attr :api_authentication_keys do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -100,7 +104,9 @@ module SoftLayer
     end
     
     ##
-    # The external authentication bindings that link an external identifier to a SoftLayer user.
+    # Retrieve the external authentication bindings that link an external identifier to a SoftLayer user.
+    # :call-seq:
+    #   external_bindings(force_update=false)
     sl_dynamic_attr :external_bindings do |resource|
       resource.should_update? do
         #only retrieved once per instance

--- a/lib/softlayer/UserCustomer.rb
+++ b/lib/softlayer/UserCustomer.rb
@@ -16,17 +16,17 @@ module SoftLayer
     include ::SoftLayer::DynamicAttribute
 
     ##
-    # :attr_reader:
+    # :attr_reader: alternate_phone
     # A portal user's secondary phone number.
     sl_attr :alternate_phone,  'alternatePhone'
 
     ##
-    # :attr_reader:
+    # :attr_reader: created
     # The date a portal user's record was created.
     sl_attr :created,          'createDate'
 
     ##
-    # :attr_reader:
+    # :attr_reader: display_name
     # The portal user's display name.
     sl_attr :display_name,     'displayName'
 
@@ -36,32 +36,32 @@ module SoftLayer
     sl_attr :email
 
     ##
-    # :attr_reader:
+    # :attr_reader: first_name
     # A portal user's first name.
     sl_attr :first_name,       'firstName'
 
     ##
-    # :attr_reader:
+    # :attr_reader: last_name
     # A portal user's last name.
     sl_attr :last_name,        'lastName'
 
     ##
-    # :attr_reader:
+    # :attr_reader: modified
     # The date a portal user's record was last modified.
     sl_attr :modified,         'modifyDate'
 
     ##
-    # :attr_reader:
+    # :attr_reader: office_phone
     # A portal user's office phone number.
     sl_attr :office_phone,     'officePhone'
 
     ##
-    # :attr_reader:
+    # :attr_reader: password_expires
     # The expiration date for the user's password.
     sl_attr :password_expires, 'passwordExpireDate'
 
     ##
-    # :attr_reader:
+    # :attr_reader: status_changed
     # The date a portal users record's last status change.
     sl_attr :status_changed,   'statusDate'
 

--- a/lib/softlayer/UserCustomer.rb
+++ b/lib/softlayer/UserCustomer.rb
@@ -115,7 +115,7 @@ module SoftLayer
 
       resource.to_update do
         external_bindings = self.service.object_mask(UserCustomerExternalBinding.default_object_mask).getExternalBindings
-        external_bindings.collect { |external_binding| UserCustomerExternalBinding.new(soflayer_client, external_binding) }
+        external_bindings.collect { |external_binding| UserCustomerExternalBinding.new(softlayer_client, external_binding) }
       end
     end
 

--- a/lib/softlayer/UserCustomerExternalBinding.rb
+++ b/lib/softlayer/UserCustomerExternalBinding.rb
@@ -22,7 +22,7 @@ module SoftLayer
     sl_attr :active
 
     ##
-    # :attr_reader:
+    # :attr_reader: created
     # The date that the external authentication binding was created.
     sl_attr :created, 'createDate'
 

--- a/lib/softlayer/UserCustomerExternalBinding.rb
+++ b/lib/softlayer/UserCustomerExternalBinding.rb
@@ -74,7 +74,7 @@ module SoftLayer
     end
 
     ##
-    # Returns the service for interacting with this user customer extnerla binding
+    # Returns the service for interacting with this user customer external binding
     # through the network API
     #
     def service

--- a/lib/softlayer/UserCustomerExternalBinding.rb
+++ b/lib/softlayer/UserCustomerExternalBinding.rb
@@ -33,7 +33,9 @@ module SoftLayer
     sl_attr :password
 
     ##
-    # An optional note for identifying the external binding.
+    # Retrieve an optional note for identifying the external binding.
+    # :call-seq:
+    #   note(force_update=false)
     sl_dynamic_attr :note do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -46,7 +48,9 @@ module SoftLayer
     end
 
     ##
-    # The user friendly name of a type of external authentication binding.
+    # Retrieve the user friendly name of a type of external authentication binding.
+    # :call-seq:
+    #   type(force_update=false)
     sl_dynamic_attr :type do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -60,7 +64,9 @@ module SoftLayer
     end
 
     ##
-    # The user friendly name of an external binding vendor.
+    # Retrieve the user friendly name of an external binding vendor.
+    # :call-seq:
+    #   vendor(force_update=false)
     sl_dynamic_attr :vendor do |resource|
       resource.should_update? do
         #only retrieved once per instance

--- a/lib/softlayer/VLANFirewall.rb
+++ b/lib/softlayer/VLANFirewall.rb
@@ -28,9 +28,7 @@ module SoftLayer
     sl_attr :VLAN_number, 'vlanNumber'
 
     ##
-    # :attr_reader:
-    #
-    # The set of rules applied by this firewall to incoming traffic.
+    # Retrieve the set of rules applied by this firewall to incoming traffic.
     # The object will retrieve the rules from the network API every
     # time you ask it for the rules.
     #
@@ -38,6 +36,8 @@ module SoftLayer
     # order that the firewall applies the rules, however please see
     # the important note in change_rules! concerning the "orderValue"
     # property of the rules.
+    # :call-seq:
+    #   rules(force_update=false)
     sl_dynamic_attr :rules do |firewall_rules|
       firewall_rules.should_update? do
         # firewall rules update every time you ask for them.

--- a/lib/softlayer/VLANFirewall.rb
+++ b/lib/softlayer/VLANFirewall.rb
@@ -120,7 +120,7 @@ module SoftLayer
     # *NOTE!* The rules themselves have an "orderValue" property.
     # It is this property, and *not* the order that the rules are
     # found in the rules_data array, which will determine in which
-    # order the firewall applies its rules to incomming traffic.
+    # order the firewall applies its rules to incoming traffic.
     #
     # *NOTE!* Changes to the rules are not applied immediately
     # on the server side. Instead, they are enqueued by the

--- a/lib/softlayer/VLANFirewall.rb
+++ b/lib/softlayer/VLANFirewall.rb
@@ -21,7 +21,7 @@ module SoftLayer
     include ::SoftLayer::DynamicAttribute
 
     ##
-    #:attr_reader:
+    # :attr_reader: VLAN_number
     #
     # The number of the VLAN protected by this firewall.
     #

--- a/lib/softlayer/VLANFirewall.rb
+++ b/lib/softlayer/VLANFirewall.rb
@@ -210,7 +210,7 @@ module SoftLayer
       softlayer_client = client || Client.default_client
       raise "#{__method__} requires a client but none was given and Client::default_client is not set" if !softlayer_client
 
-      # only VLAN firewallas have a networkVlanFirewall component
+      # only VLAN firewalls have a networkVlanFirewall component
       vlan_firewall_filter = SoftLayer::ObjectFilter.new() { |filter|
         filter.accept("networkVlans.networkVlanFirewall").when_it is_not_null
       }

--- a/lib/softlayer/VLANFirewallOrder.rb
+++ b/lib/softlayer/VLANFirewallOrder.rb
@@ -14,7 +14,7 @@ module SoftLayer
     attr_reader :vlan_id
 
     ##
-    # Set high_availabilty to true if you want redundant
+    # Set high_availability to true if you want redundant
     # firewall devices (defaults to false, no high_availability)
     attr_accessor :high_availability
 

--- a/lib/softlayer/VirtualDiskImage.rb
+++ b/lib/softlayer/VirtualDiskImage.rb
@@ -57,7 +57,9 @@ module SoftLayer
     sl_attr :uuid
 
     ##
-    # Returns coalesced disk images associated with this virtual disk image
+    # Retrieve coalesced disk images associated with this virtual disk image
+    # :call-seq:
+    #   coalesced_disk_images(force_update=false)
     sl_dynamic_attr :coalesced_disk_images do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -71,7 +73,9 @@ module SoftLayer
     end
     
     ##
-    # Returns local disk flag associated with virtual disk image
+    # Retrieve local disk flag associated with virtual disk image
+    # :call-seq:
+    #   local_disk(force_update=false)
     sl_dynamic_attr :local_disk do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -84,8 +88,10 @@ module SoftLayer
     end
 
     ##
-    # Whether this disk image is meant for storage of custom user data
-    # supplied with a Cloud Computing Instance order.
+    # Retrieve metadata as to whether this disk image is meant for 
+    # storage of custom user data supplied with a Cloud Computing Instance order.
+    # :call-seq:
+    #   metadata(force_update=false)
     sl_dynamic_attr :metadata do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -98,7 +104,9 @@ module SoftLayer
     end
 
     ##
-    # References to the software that resides on a disk image.
+    # Retrieve the references to the software that resides on a disk image.
+    # :call-seq:
+    #   software(force_update=false)
     sl_dynamic_attr :software do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -112,7 +120,9 @@ module SoftLayer
     end
 
     ##
-    # The original disk image that the current disk image was cloned from.
+    # Retrieve the original disk image that the current disk image was cloned from.
+    # :call-seq:
+    #   source_disk_image(force_update=false)
     sl_dynamic_attr :source_disk_image do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -126,7 +136,9 @@ module SoftLayer
     end
 
     ##
-    # A brief description of a virtual disk image type's function.
+    # Retrieve a brief description of a virtual disk image type's function.
+    # :call-seq:
+    #   type_description(force_update=false)
     sl_dynamic_attr :type_description do |resource|
       resource.should_update? do
         #only retrieved once per instance
@@ -140,7 +152,9 @@ module SoftLayer
     end
 
     ##
-    # A virtual disk image type's name.
+    # Retrieve a virtual disk image type's name.
+    # :call-seq:
+    #   type_name(force_update=false)
     sl_dynamic_attr :type_name do |resource|
       resource.should_update? do
         #only retrieved once per instance

--- a/lib/softlayer/VirtualDiskImage.rb
+++ b/lib/softlayer/VirtualDiskImage.rb
@@ -26,7 +26,7 @@ module SoftLayer
     sl_attr :checksum
 
     ##
-    # :attr_reader:
+    # :attr_reader: created
     # The date a disk image was created.
     sl_attr :created,    'createDate'
 
@@ -36,7 +36,7 @@ module SoftLayer
     sl_attr :description
 
     ##
-    # :attr_reader:
+    # :attr_reader: modified
     # The date a disk image was last modified.
     sl_attr :modified,   'modifyDate'
 

--- a/lib/softlayer/VirtualServer.rb
+++ b/lib/softlayer/VirtualServer.rb
@@ -17,7 +17,7 @@ module SoftLayer
 
     ##
     # :attr_reader: cores
-    # A count of the nubmer of virtual processing cores allocated
+    # A count of the number of virtual processing cores allocated
     # to the server.
     sl_attr :cores, 'maxCpu'
 
@@ -148,7 +148,7 @@ module SoftLayer
     end
 
     ##
-    # Retrive the virtual server with the given server ID from the API
+    # Retrieve the virtual server with the given server ID from the API
     #
     # The options parameter should contain:
     #

--- a/lib/softlayer/VirtualServer.rb
+++ b/lib/softlayer/VirtualServer.rb
@@ -16,7 +16,7 @@ module SoftLayer
     include ::SoftLayer::DynamicAttribute
 
     ##
-    # :attr_reader:
+    # :attr_reader: cores
     # A count of the nubmer of virtual processing cores allocated
     # to the server.
     sl_attr :cores, 'maxCpu'

--- a/lib/softlayer/VirtualServer.rb
+++ b/lib/softlayer/VirtualServer.rb
@@ -52,9 +52,9 @@ module SoftLayer
     sl_attr :lastOperatingSystemReload
 
     ##
-    # A virtual server can find out about items that are
-    # available for upgrades.
-    #
+    # Retrieve information about items that are available for upgrades.
+    # :call-seq:
+    #   upgrade_options(force_update=false)
     sl_dynamic_attr :upgrade_options do |resource|
       resource.should_update? do
         @upgrade_options == nil

--- a/lib/softlayer/VirtualServerOrder.rb
+++ b/lib/softlayer/VirtualServerOrder.rb
@@ -102,7 +102,7 @@ module SoftLayer
     # Corresponds to +primaryBackendNetworkComponent.networkVlan.id+ in the +createObject+ documentation
     attr_accessor :user_metadata
 
-    # Create a new order that works thorugh the given client connection
+    # Create a new order that works through the given client connection
     def initialize (client = nil)
       @softlayer_client = client || Client.default_client
       raise "#{__method__} requires a client but none was given and Client::default_client is not set" if !@softlayer_client
@@ -232,7 +232,7 @@ module SoftLayer
     end
 
     ##
-    # Returns a list of the valid :os_refrence_codes
+    # Returns a list of the valid :os_reference_codes
     def self.os_reference_code_options(client = nil)
       create_object_options(client)['operatingSystems'].collect { |os_spec| os_spec['template']['operatingSystemReferenceCode'] }.uniq.sort!
     end

--- a/lib/softlayer/VirtualServerOrder_Package.rb
+++ b/lib/softlayer/VirtualServerOrder_Package.rb
@@ -49,7 +49,7 @@ module SoftLayer
     # that is the +id+ of a +SoftLayer_Product_Item_Price+. Instances of the ProductConfigurationOption
     # class behave this way.
     #
-    # At a minimum, the configuation_options should include entries for each of the categories
+    # At a minimum, the configuration_options should include entries for each of the categories
     # required by the package (i.e. those returned from ProductPackage#required_categories)
     attr_accessor :configuration_options
 

--- a/lib/softlayer/VirtualServerOrder_Package.rb
+++ b/lib/softlayer/VirtualServerOrder_Package.rb
@@ -42,7 +42,7 @@ module SoftLayer
     # The domain of the server being created (i.e. 'softlayer.com' is the domain of sldn.softlayer.com)
     attr_accessor :domain
 
-    # The value of this property should be a hash. The keys of the hash are ProdcutItemCategory
+    # The value of this property should be a hash. The keys of the hash are ProductItemCategory
     # codes (like 'os' and 'ram') while the values may be Integers or Objects. The Integer values
     # should be the +id+ of a +SoftLayer_Product_Item_Price+ representing the configuration option
     # chosen for that category. Objects must respond to the +price_id+ message and return an integer

--- a/lib/softlayer/VirtualServerUpgradeOrder.rb
+++ b/lib/softlayer/VirtualServerUpgradeOrder.rb
@@ -108,7 +108,7 @@ module SoftLayer
     end
 
     ##
-    # Searches through the upgrade items pricess known to this server for the one that is in a particular category
+    # Searches through the upgrade items prices known to this server for the one that is in a particular category
     # and whose capacity matches the value given. Returns the item_price or nil
     #
     def _item_price_with_capacity(which_category, capacity)

--- a/lib/softlayer/object_mask_helpers.rb
+++ b/lib/softlayer/object_mask_helpers.rb
@@ -68,7 +68,7 @@ end
 # object masks
 class Array
   # Returns a string representing the object mask content represented by the
-  # Array. Each value in the array is converted to its object mask eqivalent
+  # Array. Each value in the array is converted to its object mask equivalent
   # This routine is an implementation detail used in the conversion of hashes
   # to object mask strings. You should not have to call this method directly.
   def _to_sl_object_mask_property()


### PR DESCRIPTION
This deals with the simple part of issue #97 where sl_attr with two args would cause rdoc to generate two attributes where only one was intended. The question of what to do about sl_dynamic_attr as discussed in #97 remains open for now awaiting more discussion.