### PR TITLE
Cleanup syntax case across classes to better follow Ruby style guide.

### DIFF
--- a/lib/softlayer/Account.rb
+++ b/lib/softlayer/Account.rb
@@ -264,6 +264,26 @@ module SoftLayer
     # The IDs of the different segments can be helpful for ordering
     # firewalls.
     #
+    def find_vlan_with_number(vlan_number)
+      filter = SoftLayer::ObjectFilter.new() { |filter|
+        filter.accept('networkVlans.vlanNumber').when_it is vlan_number
+      }
+
+      vlan_data = self.service.object_mask("mask[id,vlanNumber,primaryRouter,networkSpace]").object_filter(filter).getNetworkVlans
+      return vlan_data
+    end
+
+    ##
+    # Searches the account's list of VLANs for the ones with the given
+    # vlan number. This may return multiple results because a VLAN can
+    # span different routers and you will get a separate segment for
+    # each router.
+    #
+    # The IDs of the different segments can be helpful for ordering
+    # firewalls.
+    #
+    # DEPRECATION WARNING: This method is deprecated in favor of find_vlan_with_number
+    # and will be removed in the next major release.
     def find_VLAN_with_number(vlan_number)
       filter = SoftLayer::ObjectFilter.new() { |filter|
         filter.accept('networkVlans.vlanNumber').when_it is vlan_number

--- a/lib/softlayer/Account.rb
+++ b/lib/softlayer/Account.rb
@@ -283,7 +283,7 @@ module SoftLayer
 
       account_service = softlayer_client[:Account]
       network_hash = account_service.getObject()
-      new(softlayer_client, network_hash)
+      Account.new(softlayer_client, network_hash)
     end
 
     ##

--- a/lib/softlayer/Account.rb
+++ b/lib/softlayer/Account.rb
@@ -9,18 +9,42 @@ module SoftLayer
     include ::SoftLayer::DynamicAttribute
 
     ##
+    # :attr_reader: company_name
+    # The company name of the primary contact
+    sl_attr :company_name, 'companyName'
+
+    ##
     # :attr_reader:
     # The company name of the primary contact
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of company_name
+    # and will be removed in the next major release.
     sl_attr :companyName
+
+    ##
+    # :attr_reader: first_name
+    # The given name name of the primary contact
+    sl_attr :first_name, 'firstName'
 
     ##
     # :attr_reader:
     # The given name name of the primary contact
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of first_name
+    # and will be removed in the next major release.
     sl_attr :firstName
+
+    ##
+    # :attr_reader: last_name
+    # The surname of the primary contact
+    sl_attr :last_name, 'lastName'
 
     ##
     # :attr_reader:
     # The surname of the primary contact
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of last_name
+    # and will be removed in the next major release.
     sl_attr :lastName
 
     ##
@@ -52,13 +76,29 @@ module SoftLayer
     sl_attr :country
 
     ##
+    # :attr_reader: postal_code
+    # The postal code (in the US, aka. zip code) of the primary contact's address
+    sl_attr :postal_code, 'postalCode'
+
+    ##
     # :attr_reader:
     # The postal code (in the US, aka. zip code) of the primary contact's address
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of postal_code
+    # and will be removed in the next major release.
     sl_attr :postalCode
+
+    ##
+    # :attr_reader: office_phone
+    # The office phone number listed for the primary contact
+    sl_attr :office_phone, 'officePhone'
 
     ##
     # :attr_reader:
     # The office phone number listed for the primary contact
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of office_phone
+    # and will be removed in the next major release.
     sl_attr :officePhone
 
     ##

--- a/lib/softlayer/AccountPassword.rb
+++ b/lib/softlayer/AccountPassword.rb
@@ -79,10 +79,18 @@ module SoftLayer
     # * <b>+:datacenter+</b>                  (string/array) - Include network storage account passwords from servers matching this datacenter
     # * <b>+:domain+</b>                      (string/array) - Include network storage account passwords from servers matching this domain
     # * <b>+:hostname+</b>                    (string/array) - Include network storage account passwords from servers matching this hostname
-    # * <b>+:network_storage_server_type+</b> (string)       - Include network storage account passwords attached to this server type
-    # * <b>+:network_storage_type+</b>        (string)       - Include network storage account passwords from devices of this storage type
+    # * <b>+:network_storage_server_type+</b> (symbol)       - Include network storage account passwords attached to this server type
+    # * <b>+:network_storage_type+</b>        (symbol)       - Include network storage account passwords from devices of this storage type
     # * <b>+:tags+</b>                        (string/array) - Include network storage account passwords from servers matching these tags
     # * <b>+:username+</b>                    (string/array) - Include network storage account passwords with this username only
+    #
+    # Additionally you may provide options related to the request itself:
+    # * <b>*:account_password_object_filter*</b> (ObjectFilter) - Include network storage account passwords for account passwords that match the
+    #                                                             criteria of this object filter
+    # * <b>*:account_password_object_mask*</b>   (string)       - The object mask of properties you wish to receive for the items returned.
+    #                                                             If not provided, the result will use the default object mask
+    # * <b>*:network_storage_object_filter*</b>  (ObjectFilter) - Include network storage account passwords from network storage that matches the
+    #                                                             criteria of this object filter
     #
     def self.find_network_storage_account_passwords(options_hash = {})
       softlayer_client = options_hash[:client] || Client.default_client
@@ -197,10 +205,18 @@ module SoftLayer
     # * <b>+:datacenter+</b>                  (string/array) - Include network storage webcc passwords from servers matching this datacenter
     # * <b>+:domain+</b>                      (string/array) - Include network storage webcc passwords from servers matching this domain
     # * <b>+:hostname+</b>                    (string/array) - Include network storage webcc passwords from servers matching this hostname
-    # * <b>+:network_storage_server_type+</b> (string)       - Include network storage webcc passwords attached to this server type
-    # * <b>+:network_storage_type+</b>        (string)       - Include network storage webcc passwords from devices of this storage type
+    # * <b>+:network_storage_server_type+</b> (symbol)       - Include network storage webcc passwords attached to this server type
+    # * <b>+:network_storage_type+</b>        (symbol)       - Include network storage webcc passwords from devices of this storage type
     # * <b>+:tags+</b>                        (string/array) - Include network storage webcc passwords from servers matching these tags
     # * <b>+:username+</b>                    (string/array) - Include network storage webcc passwords with this username only
+    #
+    # Additionally you may provide options related to the request itself:
+    # * <b>*:network_storage_object_filter*</b>  (ObjectFilter) - Include network storage account passwords from network storage that matches the
+    #                                                             criteria of this object filter
+    # * <b>*:webcc_password_object_filter*</b>   (ObjectFilter) - Include network storage account passwords for webcc passwords that match the
+    #                                                             criteria of this object filter
+    # * <b>*:webcc_password_object_mask*</b>     (string)       - The object mask of properties you wish to receive for the items returned.
+    #                                                             If not provided, the result will use the default object mask
     #
     def self.find_network_storage_webcc_passwords(options_hash = {})
       softlayer_client = options_hash[:client] || Client.default_client

--- a/lib/softlayer/BareMetalServerOrder.rb
+++ b/lib/softlayer/BareMetalServerOrder.rb
@@ -78,6 +78,14 @@ module SoftLayer
     # Object responding to to_s and providing a valid URI, The URI of a post provisioning script to run on
     # this server once it is created.
     # Corresponds to +postInstallScriptUri+ in the +createObject+ documentation
+    attr_accessor :provision_script_uri
+
+    # Object responding to to_s and providing a valid URI, The URI of a post provisioning script to run on
+    # this server once it is created.
+    # Corresponds to +postInstallScriptUri+ in the +createObject+ documentation
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of provision_script_uri
+    # and will be removed in the next major release.
     attr_accessor :provision_script_URI
 
     # Boolean, If true then the server will only have a private network interface (and no public network interface)
@@ -149,13 +157,14 @@ module SoftLayer
 
       template['privateNetworkOnlyFlag'] = true if @private_network_only
 
-      template['datacenter'] = {"name" => @datacenter.name} if @datacenter
-      template['userData'] = [{'value' => @user_metadata}] if @user_metadata
-      template['networkComponents'] = [{'maxSpeed'=> @max_port_speed}] if @max_port_speed
-      template['postInstallScriptUri'] = @provision_script_URI.to_s if @provision_script_URI
-      template['sshKeys'] = @ssh_key_ids.collect { |ssh_key| {'id'=> ssh_key.to_i } } if @ssh_key_ids
-      template['primaryNetworkComponent'] = { "networkVlan" => { "id" => @public_vlan_id.to_i } } if @public_vlan_id
+      template['datacenter']                     = {"name" => @datacenter.name}     if @datacenter
+      template['userData']                       = [{'value' => @user_metadata}]    if @user_metadata
+      template['networkComponents']              = [{'maxSpeed'=> @max_port_speed}] if @max_port_speed
+      template['postInstallScriptUri']           = @provision_script_URI.to_s       if @provision_script_URI
+      template['postInstallScriptUri']           = @provision_script_uri.to_s       if @provision_script_uri
+      template['primaryNetworkComponent']        = { "networkVlan" => { "id" => @public_vlan_id.to_i } } if @public_vlan_id
       template['primaryBackendNetworkComponent'] = { "networkVlan" => {"id" => @private_vlan_id.to_i } } if @private_vlan_id
+      template['sshKeys']                        = @ssh_key_ids.collect { |ssh_key| {'id'=> ssh_key.to_i } } if @ssh_key_ids
 
       if @disks && !@disks.empty?
         template['hardDrives'] = @disks.collect do |disk|

--- a/lib/softlayer/BareMetalServerOrder_Package.rb
+++ b/lib/softlayer/BareMetalServerOrder_Package.rb
@@ -75,6 +75,13 @@ module SoftLayer
 
     # The URI of a script to execute on the server after it has been provisioned. This may be
     # any object which accepts the to_s message. The resulting string will be passed to SoftLayer API.
+    attr_accessor :provision_script_uri
+
+    # The URI of a script to execute on the server after it has been provisioned. This may be
+    # any object which accepts the to_s message. The resulting string will be passed to SoftLayer API.
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of provision_script_uri
+    # and will be removed in the next major release.
     attr_accessor :provision_script_URI
 
     # An array of the ids of SSH keys to install on the server upon provisioning
@@ -151,6 +158,7 @@ module SoftLayer
       product_order['imageTemplateGlobalIdentifier']  = @image_template.global_id         if @image_template
       product_order['location']                       = @datacenter.id                    if @datacenter
       product_order['provisionScripts']               = [@provision_script_URI.to_s]      if @provision_script_URI
+      product_order['provisionScripts']               = [@provision_script_uri.to_s]      if @provision_script_uri
       product_order['sshKeys']                        = [{ 'sshKeyIds' => @ssh_key_ids }] if @ssh_key_ids
       product_order['primaryNetworkComponent']        = { "networkVlan" => { "id" => @public_vlan_id.to_i } } if @public_vlan_id
       product_order['primaryBackendNetworkComponent'] = { "networkVlan" => {"id" => @private_vlan_id.to_i } } if @private_vlan_id

--- a/lib/softlayer/ImageTemplate.rb
+++ b/lib/softlayer/ImageTemplate.rb
@@ -212,6 +212,14 @@ module SoftLayer
     # * <b>+:name+</b>      (string/array) - Return templates with the given name
     # * <b>+:global_id+</b> (string/array) - Return templates with the given global identifier
     # * <b>+:tags+</b>      (string/array) - Return templates with the tags
+    #
+    # Additionally you may provide options related to the request itself:
+    #
+    # * <b>*:object_filter*</b> (ObjectFilter)                       - Include private image templates for templates that matche the
+    #                                                                  criteria of this object filter
+    # * <b>+:object_mask+</b>   (string, hash, or array)             - The object mask of properties you wish to receive for the items returned.
+    #                                                                  If not provided, the result will use the default object mask
+    # * <b>+:result_limit+</b>  (hash with :limit, and :offset keys) - Limit the scope of results returned.
     def self.find_private_templates(options_hash = {})
       softlayer_client = options_hash[:client] || Client.default_client
       raise "#{__method__} requires a client but none was given and Client::default_client is not set" if !softlayer_client
@@ -239,20 +247,14 @@ module SoftLayer
       account_service = softlayer_client[:Account]
       account_service = account_service.object_filter(object_filter) unless object_filter.empty?
       account_service = account_service.object_mask(default_object_mask)
+      account_service = account_service.object_mask(options_hash[:object_mask]) if options_hash[:object_mask]
 
-      if options_hash.has_key? :object_mask
-        account_service = account_service.object_mask(options_hash[:object_mask])
-      end
-
-      if options_hash.has_key?(:result_limit)
-        offset = options[:result_limit][:offset]
-        limit = options[:result_limit][:limit]
-
-        account_service = account_service.result_limit(offset, limit)
+      if options_hash[:result_limit] && options_hash[:result_limit][:offset] && options_hash[:result_limit][:limit]
+        account_service = account_service.result_limit(options_hash[:result_limit][:offset], options_hash[:result_limit][:limit])
       end
 
       templates_data = account_service.getPrivateBlockDeviceTemplateGroups
-      templates_data.collect { |template_data| new(softlayer_client, template_data) }
+      templates_data.collect { |template_data| ImageTemplate.new(softlayer_client, template_data) }
     end
 
     ##
@@ -269,6 +271,14 @@ module SoftLayer
     # * <b>+:name+</b>      (string/array) - Return templates with the given name
     # * <b>+:global_id+</b> (string/array) - Return templates with the given global identifier
     # * <b>+:tags+</b>      (string/array) - Return templates with the tags
+    #
+    # Additionally you may provide options related to the request itself:
+    #
+    # * <b>*:object_filter*</b> (ObjectFilter)                       - Include public image templates for templates that matche the
+    #                                                                  criteria of this object filter
+    # * <b>+:object_mask+</b>   (string, hash, or array)             - The object mask of properties you wish to receive for the items returned.
+    #                                                                  If not provided, the result will use the default object mask
+    # * <b>+:result_limit+</b>  (hash with :limit, and :offset keys) - Limit the scope of results returned.
     def self.find_public_templates(options_hash = {})
       softlayer_client = options_hash[:client] || Client.default_client
       raise "#{__method__} requires a client but none was given and Client::default_client is not set" if !softlayer_client
@@ -296,20 +306,14 @@ module SoftLayer
       template_service = softlayer_client[:Virtual_Guest_Block_Device_Template_Group]
       template_service = template_service.object_filter(object_filter) unless object_filter.empty?
       template_service = template_service.object_mask(default_object_mask)
+      template_service = template_service.object_mask(options_hash[:object_mask]) if options_hash[:object_mask]
 
-      if options_hash.has_key? :object_mask
-        template_service = template_service.object_mask(options_hash[:object_mask])
-      end
-
-      if options_hash.has_key?(:result_limit)
-        offset = options[:result_limit][:offset]
-        limit = options[:result_limit][:limit]
-
-        template_service = template_service.result_limit(offset, limit)
+      if options_hash[:result_limit] && options_hash[:result_limit][:offset] && options_hash[:result_limit][:limit]
+        template_service = template_service.result_limit(options_hash[:result_limit][:offset], options_hash[:result_limit][:limit])
       end
 
       templates_data = template_service.getPublicImages
-      templates_data.collect { |template_data| new(softlayer_client, template_data) }
+      templates_data.collect { |template_data| ImageTemplate.new(softlayer_client, template_data) }
     end
 
     ##
@@ -337,7 +341,7 @@ module SoftLayer
       end
 
       template_data = service.getObject
-      new(softlayer_client, template_data)
+      ImageTemplate.new(softlayer_client, template_data)
     end
 
     ##

--- a/lib/softlayer/ImageTemplate.rb
+++ b/lib/softlayer/ImageTemplate.rb
@@ -334,11 +334,8 @@ module SoftLayer
       raise "#{__method__} requires a client but none was given and Client::default_client is not set" if !softlayer_client
 
       service = softlayer_client[:Virtual_Guest_Block_Device_Template_Group].object_with_id(id)
-      service.object_mask(default_object_mask)
-
-      if options_hash.has_key? :object_mask
-        service = service.object_mask(options_hash[:object_mask])
-      end
+      service = service.object_mask(default_object_mask)
+      service = service.object_mask(options_hash[:object_mask]) if options_hash[:object_mask]
 
       template_data = service.getObject
       ImageTemplate.new(softlayer_client, template_data)

--- a/lib/softlayer/NetworkComponent.rb
+++ b/lib/softlayer/NetworkComponent.rb
@@ -6,9 +6,31 @@
 
 module SoftLayer
   class NetworkComponent < SoftLayer::ModelBase
-    sl_attr :name
-    sl_attr :port
-    sl_attr :speed
+    ##
+    # :attr_reader: max_speed
+    # A network component's maximum allowed speed,
+    sl_attr :max_speed, 'maxSpeed'
+
+    ##
+    # :attr_reader:
+    # A network component's maximum allowed speed,
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of max_speed
+    # and will be removed in the next major release.
     sl_attr :maxSpeed
+
+    ##
+    # :attr_reader:
+    # A network component's short name.
+    sl_attr :name
+
+    # :attr_reader:
+    # A network component's port number.
+    sl_attr :port
+
+    ##
+    # :attr_reader: 
+    # A network component's speed, measured in Mbit per second.
+    sl_attr :speed
   end
 end

--- a/lib/softlayer/NetworkMessageDelivery.rb
+++ b/lib/softlayer/NetworkMessageDelivery.rb
@@ -17,13 +17,27 @@ module SoftLayer
     include ::SoftLayer::DynamicAttribute
 
     ##
+    # :attr_reader: created_at
+    # The date this username/password pair was created.
+    sl_attr :created_at,  'createDate'
+
+    ##
     # :attr_reader: created
     # The date this username/password pair was created.
+    # DEPRECATION WARNING: This attribute is deprecated in favor of created_at
+    # and will be removed in the next major release.
     sl_attr :created,  'createDate'
+
+    ##
+    # :attr_reader: modified_at
+    # The date of the last modification to this username/password pair.
+    sl_attr :modified_at, 'modifyDate'
 
     ##
     # :attr_reader: modified
     # The date of the last modification to this username/password pair.
+    # DEPRECATION WARNING: This attribute is deprecated in favor of modified_at
+    # and will be removed in the next major release.
     sl_attr :modified, 'modifyDate'
 
     ##

--- a/lib/softlayer/NetworkStorage.rb
+++ b/lib/softlayer/NetworkStorage.rb
@@ -260,23 +260,12 @@ module SoftLayer
       end
       
       if options_hash[:network_storage_server_type]
-        [ :datacenter, :domain, :hostname ].each do |option|
+        [ :datacenter, :domain, :hostname, :tags ].each do |option|
           if options_hash[option]
             network_storage_object_filter.modify do |filter|
               filter.accept(option_to_filter_path[option].call(network_storage_type, options_hash[:network_storage_server_type])).when_it is(options_hash[option])
             end
           end
-        end
-
-        if options_hash[:tags]
-          network_storage_object_filter.set_criteria_for_key_path(option_to_filter_path[:tags].call(network_storage_type, options_hash[:network_storage_server_type]),
-                                                                  {
-                                                                    'operation' => 'in',
-                                                                    'options' => [{
-                                                                                    'name' => 'data',
-                                                                                    'value' => options_hash[:tags].collect{ |tag_value| tag_value.to_s }
-                                                                                  }]
-                                                                  })
         end
       end
 

--- a/lib/softlayer/NetworkStorage.rb
+++ b/lib/softlayer/NetworkStorage.rb
@@ -21,8 +21,15 @@ module SoftLayer
     sl_attr :capacity,   'capacityGb'
 
     ##
+    # :attr_reader: created_at
+    # The date a network storage volume was created.
+    sl_attr :created_at, 'createDate'
+
+    ##
     # :attr_reader: created
     # The date a network storage volume was created.
+    # DEPRECATION WARNING: This attribute is deprecated in favor of created_at
+    # and will be removed in the next major release.
     sl_attr :created,    'createDate'
 
     ##

--- a/lib/softlayer/NetworkStorage.rb
+++ b/lib/softlayer/NetworkStorage.rb
@@ -196,13 +196,20 @@ module SoftLayer
     # If no client can be found the routine will raise an error.
     #
     # You may filter the list returned by adding options:
-    # * <b>+:datacenter+</b>                  (string) - Include network storage associated with servers matching this datacenter
-    # * <b>+:domain+</b>                      (string) - Include network storage associated with servers matching this domain
-    # * <b>+:hostname+</b>                    (string) - Include network storage associated with servers matching this hostname
-    # * <b>+:network_storage_server_type+</b> (string) - Include network storage associated with this server type
-    # * <b>+:network_storage_type+</b>        (string) - Include network storage from devices of this storage type
-    # * <b>+:service+</b>                     (string) - Include network storage from devices with this service fqdn
-    # * <b>+:tags+</b>                        (Array)  - Include network storage associated with servers matching these tags
+    # * <b>+:datacenter+</b>                  (string/array) - Include network storage associated with servers matching this datacenter
+    # * <b>+:domain+</b>                      (string/array) - Include network storage associated with servers matching this domain
+    # * <b>+:hostname+</b>                    (string/array) - Include network storage associated with servers matching this hostname
+    # * <b>+:network_storage_server_type+</b> (symbol)       - Include network storage associated with this server type
+    # * <b>+:network_storage_type+</b>        (symbol)       - Include network storage from devices of this storage type
+    # * <b>+:service+</b>                     (string/array) - Include network storage from devices with this service fqdn
+    # * <b>+:tags+</b>                        (string/array) - Include network storage associated with servers matching these tags
+    #
+    # Additionally you may provide options related to the request itself:
+    # * <b>*:network_storage_object_mask*</b>   (string)             - The object mask of properties you wish to receive for the items returned.
+    #                                                                  If not provided, the result will use the default object mask
+    # * <b>*:network_storage_object_filter*</b> (ObjectFilter)       - Include network storage credentials from network storage that matches the
+    #                                                                  criteria of this object filter
+    # * <b>+:result_limit+</b>  (hash with :limit, and :offset keys) - Limit the scope of results returned.
     #
     def self.find_network_storage(options_hash  = {})
       softlayer_client = options_hash[:client] || Client.default_client
@@ -231,11 +238,11 @@ module SoftLayer
       }
 
       option_to_filter_path = {
-        :datacenter                 => lambda { |storage_type, server_type| return [ filter_label[storage_type], '.', filter_label[server_type], '.datacenter.name' ].join                  },
-        :domain                     => lambda { |storage_type, server_type| return [ filter_label[storage_type], '.', filter_label[server_type], '.domain' ].join                           },
-        :hostname                   => lambda { |storage_type, server_type| return [ filter_label[storage_type], '.', filter_label[server_type], '.hostname' ].join                         },
-        :service                    => lambda { |storage_type|              return [ filter_label[storage_type],                                 '.serviceResource.backendIpAddress' ].join },
-        :tags                       => lambda { |storage_type, server_type| return [ filter_label[storage_type], '.', filter_label[server_type], '.tagReferences.tag.name' ].join           },
+        :datacenter => lambda { |storage_type, server_type| return [ filter_label[storage_type], '.', filter_label[server_type], '.datacenter.name' ].join                  },
+        :domain     => lambda { |storage_type, server_type| return [ filter_label[storage_type], '.', filter_label[server_type], '.domain' ].join                           },
+        :hostname   => lambda { |storage_type, server_type| return [ filter_label[storage_type], '.', filter_label[server_type], '.hostname' ].join                         },
+        :service    => lambda { |storage_type|              return [ filter_label[storage_type],                                 '.serviceResource.backendIpAddress' ].join },
+        :tags       => lambda { |storage_type, server_type| return [ filter_label[storage_type], '.', filter_label[server_type], '.tagReferences.tag.name' ].join           },
       }
 
       if options_hash[:network_storage_type]
@@ -277,6 +284,10 @@ module SoftLayer
       account_service = account_service.object_filter(network_storage_object_filter) unless network_storage_object_filter.empty?
       account_service = account_service.object_mask(NetworkStorage.default_object_mask)
       account_service = account_service.object_mask(options_hash[:network_storage_object_mask]) if options_hash[:network_storage_object_mask]
+
+      if options_hash[:result_limit] && options_hash[:result_limit][:offset] && options_hash[:result_limit][:limit]
+        account_service = account_service.result_limit(options_hash[:result_limit][:offset], options_hash[:result_limit][:limit])
+      end
 
       case options_hash[:network_storage_type]
       when :evault

--- a/lib/softlayer/NetworkStorageCredential.rb
+++ b/lib/softlayer/NetworkStorageCredential.rb
@@ -17,13 +17,27 @@ module SoftLayer
     include ::SoftLayer::DynamicAttribute
 
     ##
+    # :attr_reader: created_at
+    # This is the data that the record was created in the table.
+    sl_attr :created_at,  'createDate'
+
+    ##
     # :attr_reader: created
     # This is the data that the record was created in the table.
+    # DEPRECATION WARNING: This attribute is deprecated in favor of created_at
+    # and will be removed in the next major release.
     sl_attr :created,  'createDate'
+
+    ##
+    # :attr_reader: modified_at
+    # This is the date that the record was last updated in the table.
+    sl_attr :modified_at, 'modifyDate'
 
     ##
     # :attr_reader: modified
     # This is the date that the record was last updated in the table.
+    # DEPRECATION WARNING: This attribute is deprecated in favor of modified_at
+    # and will be removed in the next major release.
     sl_attr :modified, 'modifyDate'
 
     ##

--- a/lib/softlayer/NetworkStorageCredential.rb
+++ b/lib/softlayer/NetworkStorageCredential.rb
@@ -75,14 +75,22 @@ module SoftLayer
     # If no client can be found the routine will raise an error.
     #
     # You may filter the list returned by adding options:
-    # * <b>+:datacenter+</b>                  (string/array) - Include network storage account passwords associated with servers matching this datacenter
-    # * <b>+:domain+</b>                      (string/array) - Include network storage account passwords associated with servers matching this domain
-    # * <b>+:hostname+</b>                    (string/array) - Include network storage account passwords associated with servers matching this hostname
-    # * <b>+:network_storage_server_type+</b> (string)       - Include network storage account passwords associated with services of this server type
-    # * <b>+:network_storage_type+</b>        (string)       - Include network storage account passwords from devices of this storage type
-    # * <b>+:service+</b>                     (string/array) - Include network storage account passwords from devices with this service fqdn
-    # * <b>+:tags+</b>                        (string/array) - Include network storage account passwords associated with servers matching these tags
-    # * <b>+:username+</b>                    (string/array) - Include network storage account passwords with this username only
+    # * <b>+:datacenter+</b>                  (string/array) - Include network storage credentials associated with servers matching this datacenter
+    # * <b>+:domain+</b>                      (string/array) - Include network storage credentials associated with servers matching this domain
+    # * <b>+:hostname+</b>                    (string/array) - Include network storage credentials associated with servers matching this hostname
+    # * <b>+:network_storage_server_type+</b> (symbol)       - Include network storage credentials associated with services of this server type
+    # * <b>+:network_storage_type+</b>        (symbol)       - Include network storage credentials from devices of this storage type
+    # * <b>+:service+</b>                     (string/array) - Include network storage credentials from devices with this service fqdn
+    # * <b>+:tags+</b>                        (string/array) - Include network storage credentials associated with servers matching these tags
+    # * <b>+:username+</b>                    (string/array) - Include network storage credentials with this username only
+    #
+    # Additionally you may provide options related to the request itself:
+    # * <b>*:network_storage_credential_object_filter*</b> (ObjectFilter) - Include network storage credentials that match the
+    #                                                                       criteria of this object filter
+    # * <b>*:network_storage_credential_object_mask*</b>   (string)       - The object mask of properties you wish to receive for the items returned.
+    #                                                                       If not provided, the result will use the default object mask
+    # * <b>*:network_storage_object_filter*</b>            (ObjectFilter) - Include network storage credentials from network storage that matches the
+    #                                                                       criteria of this object filter
     #
     def self.find_network_storage_credentials(options_hash = {})
       softlayer_client = options_hash[:client] || Client.default_client

--- a/lib/softlayer/NetworkStorageGroup.rb
+++ b/lib/softlayer/NetworkStorageGroup.rb
@@ -15,13 +15,27 @@ module SoftLayer
     sl_attr :alias
 
     ##
+    # :attr_reader: created_at
+    # The date this group was created.
+    sl_attr :created_at, 'createDate'
+
+    ##
     # :attr_reader: created
     # The date this group was created.
+    # DEPRECATION WARNING: This attribute is deprecated in favor of created_at
+    # and will be removed in the next major release.
     sl_attr :created, 'createDate'
+
+    ##
+    # :attr_reader: modified_at
+    # The date this group was modified.
+    sl_attr :modified_at, 'modifyDate'
 
     ##
     # :attr_reader: modified
     # The date this group was modified.
+    # DEPRECATION WARNING: This attribute is deprecated in favor of modified_at
+    # and will be removed in the next major release.
     sl_attr :modified, 'modifyDate'
 
     ##

--- a/lib/softlayer/ProductItemCategory.rb
+++ b/lib/softlayer/ProductItemCategory.rb
@@ -10,9 +10,14 @@ module SoftLayer
   # the product order is the price_id, the rest of the information is provided
   # to make the object friendly to humans who may be searching for the
   # meaning of a given price_id.
-  class ProductConfigurationOption < Struct.new(:capacity, :capacityRestrictionMaximum, :capacityRestrictionMinimum,
-     :capacityRestrictionType, :description, :hourlyRecurringFee, :laborFee, :oneTimeFee, :price_id, :recurringFee,
-     :requiredCoreCount, :setupFee, :units)
+  #
+  # DEPRECATION WARNING: The following configuration option keys have been deprecated and
+  # will be removed with the next major version: capacityRestrictionMaximum, capacityRestrictionMinimum,
+  # capacityRestrictionType, hourlyRecurringFee, laborFee, oneTimeFee, recurringFee, requiredCoreCount, setupFee
+  class ProductConfigurationOption < Struct.new(:capacity, :capacityRestrictionMaximum, :capicity_restriction_maximum,
+     :capacityRestrictionMinimum, :capacity_restriction_minimum, :capacityRestrictionType, :capacity_restriction_type,
+     :description, :hourlyRecurringFee, :hourly_recurring_fee, :laborFee, :labor_fee, :oneTimeFee, :one_time_fee,
+     :price_id, :recurringFee, :recurring_fee, :requiredCoreCount, :required_core_count, :setupFee, :setup_fee, :units)
     # Is it evil, or just incongruous to give methods to a struct?
 
     def initialize(package_item_data, price_item_data)
@@ -20,6 +25,7 @@ module SoftLayer
       self.description = package_item_data['description']
       self.units       = package_item_data['units']
 
+      #DEPRECATION WARNING: All these are deprecated and will be removed with the next major version, pleace use keys below
       self.capacityRestrictionMaximum = price_item_data['capacityRestrictionMaximum'] ? price_item_data['capacityRestrictionMaximum'] : nil
       self.capacityRestrictionMinimum = price_item_data['capacityRestrictionMinimum'] ? price_item_data['capacityRestrictionMinimum'] : nil
       self.capacityRestrictionType    = price_item_data['capacityRestrictionType']    ? price_item_data['capacityRestrictionType']    : nil
@@ -30,6 +36,16 @@ module SoftLayer
       self.recurringFee               = price_item_data['recurringFee']               ? price_item_data['recurringFee'].to_f          : 0.0
       self.requiredCoreCount          = price_item_data['requiredCoreCount']          ? price_item_data['requiredCoreCount']          : nil
       self.setupFee                   = price_item_data['setupFee']                   ? price_item_data['setupFee'].to_f              : 0.0
+
+      self.capacity_restriction_maximum = price_item_data['capacityRestrictionMaximum'] ? price_item_data['capacityRestrictionMaximum'] : nil
+      self.capacity_restriction_minimum = price_item_data['capacityRestrictionMinimum'] ? price_item_data['capacityRestrictionMinimum'] : nil
+      self.capacity_restriction_type    = price_item_data['capacityRestrictionType']    ? price_item_data['capacityRestrictionType']    : nil
+      self.hourly_recurring_fee         = price_item_data['hourlyRecurringFee']         ? price_item_data['hourlyRecurringFee'].to_f    : 0.0
+      self.labor_fee                    = price_item_data['laborFee']                   ? price_item_data['laborFee'].to_f              : 0.0
+      self.one_time_fee                 = price_item_data['oneTimeFee']                 ? price_item_data['oneTimeFee'].to_f            : 0.0
+      self.recurring_fee                = price_item_data['recurringFee']               ? price_item_data['recurringFee'].to_f          : 0.0
+      self.required_core_count          = price_item_data['requiredCoreCount']          ? price_item_data['requiredCoreCount']          : nil
+      self.setup_fee                    = price_item_data['setupFee']                   ? price_item_data['setupFee'].to_f              : 0.0
     end
 
     # returns true if the configuration option has no fees associated with it.
@@ -52,9 +68,18 @@ module SoftLayer
     include ::SoftLayer::DynamicAttribute
 
     ##
+    # :attr_reader: category_code
+    # The categoryCode is a primary identifier for a particular
+    # category.  It is a string like 'os' or 'ram'
+    sl_attr :category_code, 'categoryCode'
+
+    ##
     # :attr_reader:
     # The categoryCode is a primary identifier for a particular
     # category.  It is a string like 'os' or 'ram'
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of category_code
+    # and will be removed in the next major release.
     sl_attr :categoryCode
 
     ##

--- a/lib/softlayer/ProductPackage.rb
+++ b/lib/softlayer/ProductPackage.rb
@@ -127,7 +127,7 @@ module SoftLayer
     ##
     # Returns the product category with the given category code (or nil if one cannot be found)
     def category(category_code)
-      categories.find { |category| category.categoryCode == category_code }
+      categories.find { |category| category.category_code == category_code }
     end
 
     ##

--- a/lib/softlayer/Server.rb
+++ b/lib/softlayer/Server.rb
@@ -29,15 +29,15 @@ module SoftLayer
     sl_attr :domain
 
     ##
-    # :attr_reader: fully_qualified_domain_name
+    # :attr_reader: fqdn
     # A convenience attribute that combines the hostname and domain name
-    sl_attr :fully_qualified_domain_name, 'fullyQualifiedDomainName'
+    sl_attr :fqdn, 'fullyQualifiedDomainName'
 
     ##
     # :attr_reader:
     # A convenience attribute that combines the hostname and domain name
     #
-    # DEPRECATION WARNING: This attribute is deprecated in favor of fully_qualified_domain_name
+    # DEPRECATION WARNING: This attribute is deprecated in favor of fqdn
     # and will be removed in the next major release.
     sl_attr :fullyQualifiedDomainName
 

--- a/lib/softlayer/Server.rb
+++ b/lib/softlayer/Server.rb
@@ -29,8 +29,16 @@ module SoftLayer
     sl_attr :domain
 
     ##
+    # :attr_reader: fully_qualified_domain_name
+    # A convenience attribute that combines the hostname and domain name
+    sl_attr :fully_qualified_domain_name, 'fullyQualifiedDomainName'
+
+    ##
     # :attr_reader:
     # A convenience attribute that combines the hostname and domain name
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of fully_qualified_domain_name
+    # and will be removed in the next major release.
     sl_attr :fullyQualifiedDomainName
 
     ##

--- a/lib/softlayer/ServerFirewall.rb
+++ b/lib/softlayer/ServerFirewall.rb
@@ -15,7 +15,7 @@ module SoftLayer
   # Instances of this class roughly correspond to instances of the
   # SoftLayer_Network_Component_Firewall service entity.
   #
-	class ServerFirewall < SoftLayer::ModelBase
+  class ServerFirewall < SoftLayer::ModelBase
     include ::SoftLayer::DynamicAttribute
 
     ##

--- a/lib/softlayer/ServerFirewall.rb
+++ b/lib/softlayer/ServerFirewall.rb
@@ -216,11 +216,11 @@ module SoftLayer
       end
 
       bare_metal_firewalls = bare_metal_firewalls_data.collect { |bare_metal_firewall_data|
-        self.new(softlayer_client, bare_metal_firewall_data)
+        ServerFirewall.new(softlayer_client, bare_metal_firewall_data)
       }
 
       virtual_server_firewalls = virtual_firewalls_data.collect { |virtual_firewall_data|
-        self.new(softlayer_client, virtual_firewall_data)
+        ServerFirewall.new(softlayer_client, virtual_firewall_data)
       }
 
       return bare_metal_firewalls + virtual_server_firewalls

--- a/lib/softlayer/SoftwarePassword.rb
+++ b/lib/softlayer/SoftwarePassword.rb
@@ -14,15 +14,29 @@ module SoftLayer
   #
   class SoftwarePassword < ModelBase
     include ::SoftLayer::DynamicAttribute
+
+    ##
+    # :attr_reader: created_at
+    # The date this username/password pair was created.
+    sl_attr :created_at, 'createDate'
     
     ##
     # :attr_reader: created
     # The date this username/password pair was created.
+    # DEPRECATION WARNING: This attribute is deprecated in favor of created_at
+    # and will be removed in the next major release.
     sl_attr :created, 'createDate'
+
+    ##
+    # :attr_reader: modified_at
+    # The date of the last modification to this username/password pair.
+    sl_attr :modified_at, 'modifyDate'
 
     ##
     # :attr_reader: modified
     # The date of the last modification to this username/password pair.
+    # DEPRECATION WARNING: This attribute is deprecated in favor of modified_at
+    # and will be removed in the next major release.
     sl_attr :modified, 'modifyDate'
 
     ##

--- a/lib/softlayer/SoftwarePassword.rb
+++ b/lib/softlayer/SoftwarePassword.rb
@@ -79,10 +79,17 @@ module SoftLayer
     # If no client can be found the routine will raise an error.
     #
     # You may filter the list returned by adding options:
-    # * <b>+:datacenter+</b>    (string/array) - Include software passwords from application delivery controllers matching this datacenter
-    # * <b>+:name+</b>          (string/array) - Include software passwords from application delivery controllers that matches this name
-    # * <b>+:tags+</b>          (string/array  - Include software passwords from application delivery controllers that matches these tags
-    # * <b>+:username+</b>      (string/array) - Include software passwords that match this username
+    # * <b>+:datacenter+</b> (string/array) - Include software passwords from application delivery controllers matching this datacenter
+    # * <b>+:name+</b>       (string/array) - Include software passwords from application delivery controllers that matches this name
+    # * <b>+:tags+</b>       (string/array  - Include software passwords from application delivery controllers that matches these tags
+    # * <b>+:username+</b>   (string/array) - Include software passwords that match this username
+    #
+    # Additionally you may provide options related to the request itself:
+    # * <b>*:application_delivery_controller_object_filter*</b> (ObjectFilter) - Include software passwords from application delivery controllers
+    #                                                                            that matches the criteria of this object filter
+    # * <b>*:software_password_object_filter*</b>               (ObjectFilter) - Include software passwords that match the criteria of this object filter
+    # * <b>*:software_password_object_mask*</b>                 (string)       - The object mask of properties you wish to receive for the items returned.
+    #                                                                            If not provided, the result will use the default object mask
     #
     def self.find_passwords_for_application_delivery_controllers(options_hash = {})
       softlayer_client = options_hash[:client] || Client.default_client
@@ -166,6 +173,15 @@ module SoftLayer
     # * <b>+:vlan_fw_tags+</b>  (string/array) - Include software passwords from vlan firewalls that matches these tags
     # * <b>+:vlan_fw_type+</b>  (string/array) - Include software passwords from vlan firewalls that match this type
     # * <b>+:username+</b>      (string/array) - Include software passwords that match this username
+    #
+    # Additionally you may provide options related to the request itself:
+    # * <b>*:software_password_object_filter*</b> (ObjectFilter) - Include software passwords that match the criteria of this object filter
+    # * <b>*:software_password_object_mask*</b>   (string)       - The object mask of properties you wish to receive for the items returned.
+    #                                                              If not provided, the result will use the default object mask
+    # * <b>*:vlan_firewall_object_filter*</b>     (ObjectFilter) - Include software passwords from vlan firewalls that match the
+    #                                                              criteria of this object filter
+    # * <b>*:vlan_object_filter*</b>              (ObjectFilter) - Include software passwords from vlan firewalls whose vlans match the
+    #                                                              criteria of this object filter
     #
     def self.find_passwords_for_vlan_firewalls(options_hash = {})
       softlayer_client = options_hash[:client] || Client.default_client

--- a/lib/softlayer/Ticket.rb
+++ b/lib/softlayer/Ticket.rb
@@ -18,15 +18,15 @@ module SoftLayer
     sl_attr :subject
 
     ##
-    # :attr_reader: last_edited
+    # :attr_reader: last_edited_at
     # The date the ticket was last updated.
-    sl_attr :last_edited, 'lastEditDate'
+    sl_attr :last_edited_at, 'lastEditDate'
 
     ##
     # :attr_reader:
     # The date the ticket was last updated.
     #
-    # DEPRECATION WARNING: This attribute is deprecated in favor of last_edited
+    # DEPRECATION WARNING: This attribute is deprecated in favor of last_edited_at
     # and will be removed in the next major release.
     sl_attr :lastEditDate
 

--- a/lib/softlayer/Ticket.rb
+++ b/lib/softlayer/Ticket.rb
@@ -127,13 +127,11 @@ module SoftLayer
       softlayer_client = options[:client] || Client.default_client
       raise "#{__method__} requires a client but none was given and Client::default_client is not set" if !softlayer_client
 
-      if options.has_key?(:object_mask)
-        object_mask = options[:object_mask]
-      else
-        object_mask = default_object_mask.to_sl_object_mask
-      end
+      ticket_service = softlayer_client[:Ticket].object_with_id(ticket_id)
+      ticket_service = ticket_service.object_mask(default_object_mask.to_sl_object_mask)
+      ticket_service = ticket_service.object_mask(options[:object_mask]) if options[:object_mask]
 
-      ticket_data = softlayer_client[:Ticket].object_with_id(ticket_id).object_mask(object_mask).getObject()
+      ticket_data    = ticket_service.getObject()
 
       return Ticket.new(softlayer_client, ticket_data)
     end

--- a/lib/softlayer/Ticket.rb
+++ b/lib/softlayer/Ticket.rb
@@ -120,6 +120,9 @@ module SoftLayer
     # If a client is not provided then the routine will search Client::default_client
     # If Client::default_client is also nil the routine will raise an error.
     #
+    # Additionally you may provide options related to the request itself:
+    # * <b>*:object_mask*</b> (string) - The object mask of properties you wish to receive for the items returned.
+    #                                    If not provided, the result will use the default object mask
     def self.ticket_with_id(ticket_id, options = {})
       softlayer_client = options[:client] || Client.default_client
       raise "#{__method__} requires a client but none was given and Client::default_client is not set" if !softlayer_client
@@ -132,7 +135,7 @@ module SoftLayer
 
       ticket_data = softlayer_client[:Ticket].object_with_id(ticket_id).object_mask(object_mask).getObject()
 
-      return new(softlayer_client, ticket_data)
+      return Ticket.new(softlayer_client, ticket_data)
     end
 
     ##

--- a/lib/softlayer/Ticket.rb
+++ b/lib/softlayer/Ticket.rb
@@ -18,8 +18,16 @@ module SoftLayer
     sl_attr :subject
 
     ##
+    # :attr_reader: last_edited
+    # The date the ticket was last updated.
+    sl_attr :last_edited, 'lastEditDate'
+
+    ##
     # :attr_reader:
     # The date the ticket was last updated.
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of last_edited
+    # and will be removed in the next major release.
     sl_attr :lastEditDate
 
     ##

--- a/lib/softlayer/UserCustomer.rb
+++ b/lib/softlayer/UserCustomer.rb
@@ -21,8 +21,15 @@ module SoftLayer
     sl_attr :alternate_phone,  'alternatePhone'
 
     ##
+    # :attr_reader: created_at
+    # The date a portal user's record was created.
+    sl_attr :created_at,          'createDate'
+
+    ##
     # :attr_reader: created
     # The date a portal user's record was created.
+    # DEPRECATION WARNING: This attribute is deprecated in favor of created_at
+    # and will be removed in the next major release.
     sl_attr :created,          'createDate'
 
     ##
@@ -46,8 +53,15 @@ module SoftLayer
     sl_attr :last_name,        'lastName'
 
     ##
+    # :attr_reader: modified_at
+    # The date a portal user's record was last modified.
+    sl_attr :modified_at,         'modifyDate'
+
+    ##
     # :attr_reader: modified
     # The date a portal user's record was last modified.
+    # DEPRECATION WARNING: This attribute is deprecated in favor of modified_at
+    # and will be removed in the next major release.
     sl_attr :modified,         'modifyDate'
 
     ##

--- a/lib/softlayer/UserCustomerExternalBinding.rb
+++ b/lib/softlayer/UserCustomerExternalBinding.rb
@@ -22,8 +22,15 @@ module SoftLayer
     sl_attr :active
 
     ##
+    # :attr_reader: created_at
+    # The date that the external authentication binding was created.
+    sl_attr :created_at, 'createDate'
+
+    ##
     # :attr_reader: created
     # The date that the external authentication binding was created.
+    # DEPRECATION WARNING: This attribute is deprecated in favor of created_at
+    # and will be removed in the next major release.
     sl_attr :created, 'createDate'
 
     ##

--- a/lib/softlayer/VLANFirewall.rb
+++ b/lib/softlayer/VLANFirewall.rb
@@ -79,7 +79,7 @@ module SoftLayer
     ##
     # The fully qualified domain name of the physical device the
     # firewall is implemented by.
-    def fully_qualified_domain_name
+    def fqdn
       if self.has_sl_property?('networkVlanFirewall')
         return self['networkVlanFirewall']['fullyQualifiedDomainName']
       else
@@ -91,7 +91,7 @@ module SoftLayer
     # The fully qualified domain name of the physical device the
     # firewall is implemented by.
     #
-    # DEPRECATION WARNING: This method is deprecated in favor of fully_qualified_domain_name
+    # DEPRECATION WARNING: This method is deprecated in favor of fqdn
     # and will be removed in the next major release.
     def fullyQualifiedDomainName
       if self.has_sl_property?('networkVlanFirewall')

--- a/lib/softlayer/VLANFirewall.rb
+++ b/lib/softlayer/VLANFirewall.rb
@@ -21,10 +21,18 @@ module SoftLayer
     include ::SoftLayer::DynamicAttribute
 
     ##
+    # :attr_reader: vlan_number
+    #
+    # The number of the VLAN protected by this firewall.
+    sl_attr :vlan_number, 'vlanNumber'
+
+    ##
     # :attr_reader: VLAN_number
     #
     # The number of the VLAN protected by this firewall.
     #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of vlan_number
+    # and will be removed in the next major release.
     sl_attr :VLAN_number, 'vlanNumber'
 
     ##
@@ -54,6 +62,16 @@ module SoftLayer
     ##
     # Returns the name of the primary router the firewall is attached to.
     # This is often a "customer router" in one of the datacenters.
+    def primary_router
+      return self['primaryRouter']['hostname']
+    end
+
+    ##
+    # Returns the name of the primary router the firewall is attached to.
+    # This is often a "customer router" in one of the datacenters.
+    #
+    # DEPRECATION WARNING: This method is deprecated in favor of primary_router
+    # and will be removed in the next major release.
     def primaryRouter
       return self['primaryRouter']['hostname']
     end
@@ -61,6 +79,20 @@ module SoftLayer
     ##
     # The fully qualified domain name of the physical device the
     # firewall is implemented by.
+    def fully_qualified_domain_name
+      if self.has_sl_property?('networkVlanFirewall')
+        return self['networkVlanFirewall']['fullyQualifiedDomainName']
+      else
+        return @softlayer_hash
+      end
+    end
+
+    ##
+    # The fully qualified domain name of the physical device the
+    # firewall is implemented by.
+    #
+    # DEPRECATION WARNING: This method is deprecated in favor of fully_qualified_domain_name
+    # and will be removed in the next major release.
     def fullyQualifiedDomainName
       if self.has_sl_property?('networkVlanFirewall')
         return self['networkVlanFirewall']['fullyQualifiedDomainName']

--- a/lib/softlayer/VirtualDiskImage.rb
+++ b/lib/softlayer/VirtualDiskImage.rb
@@ -26,8 +26,15 @@ module SoftLayer
     sl_attr :checksum
 
     ##
+    # :attr_reader: created_at
+    # The date a disk image was created.
+    sl_attr :created_at,    'createDate'
+
+    ##
     # :attr_reader: created
     # The date a disk image was created.
+    # DEPRECATION WARNING: This attribute is deprecated in favor of created_at
+    # and will be removed in the next major release.
     sl_attr :created,    'createDate'
 
     ##
@@ -36,8 +43,15 @@ module SoftLayer
     sl_attr :description
 
     ##
+    # :attr_reader: modified_at
+    # The date a disk image was last modified.
+    sl_attr :modified_at,   'modifyDate'
+
+    ##
     # :attr_reader: modified
     # The date a disk image was last modified.
+    # DEPRECATION WARNING: This attribute is deprecated in favor of modified_at
+    # and will be removed in the next major release.
     sl_attr :modified,   'modifyDate'
 
     ##

--- a/lib/softlayer/VirtualServer.rb
+++ b/lib/softlayer/VirtualServer.rb
@@ -243,8 +243,9 @@ module SoftLayer
     # * <b>+:private_ip+</b> (string/array) - same as :public_ip, but for private IP addresses
     #
     # Additionally you may provide options related to the request itself:
-    # * <b>+:object_mask+</b> (string) - A object mask of properties, in addition to the default properties, that you wish to retrieve for the servers
-    # * <b>+:result_limit+</b> (hash with :limit, and :offset keys) - Limit the scope of results returned.
+    # * <b>*:object_filter*</b>                       (ObjectFilter) - Include servers that match the criteria of this object filter
+    # * <b>+:object_mask+</b>                         (string)       - A object mask of properties, in addition to the default properties, that you wish to retrieve for the servers
+    # * <b>+:result_limit+</b>  (hash with :limit, and :offset keys) - Limit the scope of results returned.
     #
     def self.find_servers(options_hash = {})
       softlayer_client = options_hash[:client] || Client.default_client
@@ -286,16 +287,10 @@ module SoftLayer
       account_service = softlayer_client[:Account]
       account_service = account_service.object_filter(object_filter) unless object_filter.empty?
       account_service = account_service.object_mask(default_object_mask.to_sl_object_mask)
+      account_service = account_service.object_mask(options_hash[:object_mask]) if options_hash[:object_mask]
 
-      if options_hash.has_key? :object_mask
-        account_service = account_service.object_mask(options_hash[:object_mask])
-      end
-
-      if options_hash.has_key?(:result_limit)
-        offset = options[:result_limit][:offset]
-        limit = options[:result_limit][:limit]
-
-        account_service = account_service.result_limit(offset, limit)
+      if options_hash[:result_limit] && options_hash[:result_limit][:offset] && options_hash[:result_limit][:limit]
+        account_service = account_service.result_limit(options_hash[:result_limit][:offset], options_hash[:result_limit][:limit])
       end
 
       case

--- a/lib/softlayer/VirtualServer.rb
+++ b/lib/softlayer/VirtualServer.rb
@@ -22,12 +22,12 @@ module SoftLayer
     sl_attr :cores, 'maxCpu'
 
     ##
-    # :attr_reader: provision_date
+    # :attr_reader: provisioned_at
     # The date the Virtual Server was provisioned.  This attribute can be
     # nil if the SoftLayer system has not yet finished provisioning the
     # server (consequently this attribute is used by the #wait_until_ready
     # method to determine when a server has been provisioned)
-    sl_attr :provision_date, 'provisionDate'
+    sl_attr :provisioned_at, 'provisionDate'
 
     ##
     # :attr_reader:
@@ -36,7 +36,7 @@ module SoftLayer
     # server (consequently this attribute is used by the #wait_until_ready
     # method to determine when a server has been provisioned)
     #
-    # DEPRECATION WARNING: This attribute is deprecated in favor of provision_date
+    # DEPRECATION WARNING: This attribute is deprecated in favor of provisioned_at
     # and will be removed in the next major release.
     sl_attr :provisionDate
 

--- a/lib/softlayer/VirtualServer.rb
+++ b/lib/softlayer/VirtualServer.rb
@@ -22,26 +22,65 @@ module SoftLayer
     sl_attr :cores, 'maxCpu'
 
     ##
+    # :attr_reader: provision_date
+    # The date the Virtual Server was provisioned.  This attribute can be
+    # nil if the SoftLayer system has not yet finished provisioning the
+    # server (consequently this attribute is used by the #wait_until_ready
+    # method to determine when a server has been provisioned)
+    sl_attr :provision_date, 'provisionDate'
+
+    ##
     # :attr_reader:
     # The date the Virtual Server was provisioned.  This attribute can be
     # nil if the SoftLayer system has not yet finished provisioning the
     # server (consequently this attribute is used by the #wait_until_ready
     # method to determine when a server has been provisioned)
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of provision_date
+    # and will be removed in the next major release.
     sl_attr :provisionDate
+
+    ##
+    # :attr_reader: active_transaction
+    # The active transaction (if any) for this virtual server. Transactions
+    # are used to make configuration changes to the server and only one
+    # transaction can be active at a time.
+    sl_attr :active_transaction, 'activeTransaction'
 
     ##
     # :attr_reader:
     # The active transaction (if any) for this virtual server. Transactions
     # are used to make configuration changes to the server and only one
     # transaction can be active at a time.
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of active_transaction
+    # and will be removed in the next major release.
     sl_attr :activeTransaction
+
+    ##
+    # :attr_reader: block_devices
+    # Storage devices attached to the server. Storage may be local
+    # to the host running the Virtual Server, or it may be located
+    # on the SAN
+    sl_attr :block_devices, 'blockDevices'
 
     ##
     # :attr_reader:
     # Storage devices attached to the server. Storage may be local
     # to the host running the Virtual Server, or it may be located
     # on the SAN
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of block_devices
+    # and will be removed in the next major release.
     sl_attr :blockDevices
+
+    ##
+    # :attr_reader: last_operating_system_reload
+    # The last operating system reload transaction that was
+    # run for this server. #wait_until_ready compares the
+    # ID of this transaction to the ID of the active transaction
+    # to determine if an OS reload is in progress.
+    sl_attr :last_operating_system_reload, 'lastOperatingSystemReload'
 
     ##
     # :attr_reader:
@@ -49,6 +88,9 @@ module SoftLayer
     # run for this server. #wait_until_ready compares the
     # ID of this transaction to the ID of the active transaction
     # to determine if an OS reload is in progress.
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of last_operating_system_reload
+    # and will be removed in the next major release.
     sl_attr :lastOperatingSystemReload
 
     ##
@@ -130,7 +172,7 @@ module SoftLayer
         has_os_reload = has_sl_property? :lastOperatingSystemReload
         has_active_transaction = has_sl_property? :activeTransaction
 
-        reloading_os = has_active_transaction && has_os_reload && (self.lastOperatingSystemReload['id'] == self.activeTransaction['id'])
+        reloading_os = has_active_transaction && has_os_reload && (self.last_operating_system_reload['id'] == self.active_transaction['id'])
         provisioned = has_sl_property?(:provisionDate) && ! self['provisionDate'].empty?
 
         # a server is ready when it is provisioned, not reloading the OS

--- a/lib/softlayer/VirtualServerOrder.rb
+++ b/lib/softlayer/VirtualServerOrder.rb
@@ -84,6 +84,12 @@ module SoftLayer
     attr_accessor :private_vlan_id
 
     # String, The URI of a post provisioning script to run on this server once it is created
+    attr_accessor :provision_script_uri
+
+    # String, The URI of a post provisioning script to run on this server once it is created
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of provision_script_uri
+    # and will be removed in the next major release.
     attr_accessor :provision_script_URI
 
     # Integer, The id of the public VLAN this server should join
@@ -156,13 +162,14 @@ module SoftLayer
       template['dedicatedAccountHostOnlyFlag'] = true if @dedicated_host_only
       template['privateNetworkOnlyFlag'] = true if @private_network_only
 
-      template['datacenter'] = {"name" => @datacenter.name} if @datacenter
-      template['userData'] = [{'value' => @user_metadata}] if @user_metadata
-      template['networkComponents'] = [{'maxSpeed'=> @max_port_speed}] if @max_port_speed
-      template['postInstallScriptUri'] = @provision_script_URI.to_s if @provision_script_URI
-      template['sshKeys'] = @ssh_key_ids.collect { |ssh_key_id| {'id'=> ssh_key_id.to_i } } if @ssh_key_ids
-      template['primaryNetworkComponent'] = { "networkVlan" => { "id" => @public_vlan_id.to_i } } if @public_vlan_id
+      template['datacenter']                     = {"name" => @datacenter.name}     if @datacenter
+      template['userData']                       = [{'value' => @user_metadata}]    if @user_metadata
+      template['networkComponents']              = [{'maxSpeed'=> @max_port_speed}] if @max_port_speed
+      template['postInstallScriptUri']           = @provision_script_URI.to_s       if @provision_script_URI
+      template['postInstallScriptUri']           = @provision_script_uri.to_s       if @provision_script_uri
+      template['primaryNetworkComponent']        = { "networkVlan" => { "id" => @public_vlan_id.to_i } } if @public_vlan_id
       template['primaryBackendNetworkComponent'] = { "networkVlan" => {"id" => @private_vlan_id.to_i } } if @private_vlan_id
+      template['sshKeys']                        = @ssh_key_ids.collect { |ssh_key_id| {'id'=> ssh_key_id.to_i } } if @ssh_key_ids
 
       if @image_template
           template['blockDeviceTemplateGroup'] = {"globalIdentifier" => @image_template.global_id}

--- a/lib/softlayer/VirtualServerOrder_Package.rb
+++ b/lib/softlayer/VirtualServerOrder_Package.rb
@@ -75,6 +75,13 @@ module SoftLayer
 
     # The URI of a script to execute on the server after it has been provisioned. This may be
     # any object which accepts the to_s message. The resulting string will be passed to SoftLayer API.
+    attr_accessor :provision_script_uri
+
+    # The URI of a script to execute on the server after it has been provisioned. This may be
+    # any object which accepts the to_s message. The resulting string will be passed to SoftLayer API.
+    #
+    # DEPRECATION WARNING: This attribute is deprecated in favor of provision_script_uri
+    # and will be removed in the next major release.
     attr_accessor :provision_script_URI
 
     # An array of the ids of SSH keys to install on the server upon provisioning
@@ -150,6 +157,7 @@ module SoftLayer
       product_order['imageTemplateGlobalIdentifier']  = @image_template.global_id         if @image_template
       product_order['location']                       = @datacenter.id                    if @datacenter
       product_order['provisionScripts']               = [@provision_script_URI.to_s]      if @provision_script_URI
+      product_order['provisionScripts']               = [@provision_script_uri.to_s]      if @provision_script_uri
       product_order['sshKeys']                        = [{ 'sshKeyIds' => @ssh_key_ids }] if @ssh_key_ids
       product_order['virtualGuests'][0]['userData']   = @user_metadata                    if @user_metadata
       product_order['primaryNetworkComponent']        = { "networkVlan" => { "id" => @public_vlan_id.to_i } } if @public_vlan_id


### PR DESCRIPTION
This addresses issues raised in #99.

We fix most of the case issues and mark the old ones as deprecated and for removal with v4.

v4-cleanup-required