### PR TITLE
Add vendor/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ internal_examples/
 doc/
 coverage/
 Gemfile.lock
+vendor/


### PR DESCRIPTION
This allows developers to install project dependencies under _vendor/_ without it polluting the `git status` view.