### PR TITLE
Fix coveralls version to a version not requiring Ruby >1.9 (fixes build on jruby1.9)

### DIFF
--- a/softlayer_api.gemspec
+++ b/softlayer_api.gemspec
@@ -27,5 +27,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rdoc', '>=2.4.2'
   s.add_development_dependency 'json', '~> 1.8', '>= 1.8.1'
-  s.add_development_dependency 'coveralls'
+  # Fixing the following gems' versions to avoid requiring
+  # Ruby 2.0.
+  s.add_development_dependency 'mime-types', '= 2.99.3'
+  s.add_development_dependency 'coveralls', '= 0.7.2'
 end


### PR DESCRIPTION
The coveralls development dependency requires tins, which requires
Ruby 2.0. Without removing this from .travis.yml, travis will continue to show failed checks.