### PR TITLE
Enable serialization of nil values in structures sent to the API

### DIFF
--- a/lib/softlayer/Service.rb
+++ b/lib/softlayer/Service.rb
@@ -14,9 +14,11 @@ ensure
   $VERBOSE = old_verbose
 end
 
-# enable parsing of "nil" values in structures returned from the API
 with_warnings(nil) {
+  # enable parsing of "nil" values in structures returned from the API
   XMLRPC::Config.const_set('ENABLE_NIL_PARSER', true)
+  # enable serialization of "nil" values in structures sent to the API
+  XMLRPC::Config.const_set('ENABLE_NIL_CREATE', true)
 }
 
 # The XML-RPC spec calls for the "faultCode" in faults to be an integer


### PR DESCRIPTION
Nil values can be sent to the API as shown in
https://softlayer.github.io/python/order_quote/.
Without this change, if we tried to do the same thing in softlayer-
ruby, the xmlrpc library returns an error as it is not configured
to serialize nil values.