### PR TITLE
Change available locations to regions for Product Package

### DIFF
--- a/doc_src/ContributionGuide.md
+++ b/doc_src/ContributionGuide.md
@@ -64,7 +64,7 @@ gems are built into the `pkg` directory and will have a name of the form `softla
 
 You can install your modified gem to your system with the gem command:
 
-    $ bundle gem install pkg/softlayer_api-<version>.gem
+    $ bundle exec gem install pkg/softlayer_api-<version>.gem
 
 (don't forget to substitute the version you are installing where the `<version>` tag appears in the command line above)
 
@@ -138,4 +138,3 @@ If you intend to offer new models, please carefully review the Model Layer docum
 # Submitting Changes
 
 Contributions are made to the `softlayer_api` Gem by submitting a pull-request on GitHub. The community will review pull requests and offer constructive advice on improvements.  The determination on whether a pull-request will be accepted into the gem is made at the sole discretion of SoftLayer with the wise counsel of the community.
-

--- a/lib/softlayer/ProductPackage.rb
+++ b/lib/softlayer/ProductPackage.rb
@@ -45,7 +45,7 @@ module SoftLayer
     ##
     # :attr_reader: available_locations
     # The list of locations where this product package is available.
-    sl_attr :available_locations, 'availableLocations'
+    sl_attr :available_locations, 'regions'
 
     ##
     # Retrieve the set of product categories needed to make an order for this product package.
@@ -230,7 +230,7 @@ module SoftLayer
                                            "groups.prices.requiredCoreCount" ].join(",") + "]"
 
     def self.default_object_mask(root)
-      "#{root}[id,name,description,availableLocations.location]"
+      "#{root}[id,name,description,regions]"
     end
   end
 end # SoftLayer


### PR DESCRIPTION
This pull request is to close issue #126.

The list of changes:
1. renamed availableLocations to regions as availableLocations are deprecated
2. added a missing 'exec' in the contribution guide

I don't know if it's better to rename :available_locations to :available_regions... Maybe it will break someone's code, but as no-one has reported that before, probably it won't break anything. :smile: 
Anyway, the regions format is different than availableLocations. So you cannot avoid changes in your tools/applications which use this gem. 