### PR TITLE
Support multiple profiles

### DIFF
--- a/lib/softlayer/Config.rb
+++ b/lib/softlayer/Config.rb
@@ -121,7 +121,8 @@ module SoftLayer
       search_path.each do |file_path|
         if File.readable? file_path
           config            = ConfigParser.new file_path
-          softlayer_section = config['softlayer']
+          profile_name = ENV['SL_PROFILE'] || 'softlayer'
+          softlayer_section = config[profile_name]
 
           if softlayer_section
             result[:api_key]      = softlayer_section['api_key'] if softlayer_section['api_key']


### PR DESCRIPTION
Allow multiple profiles to exist in the softlayer credential file.
The current implementation only allows one set of creds under a key of ['softlayer']

Proposed implementation allows multiple sets of credentials in the file using an environment variable of "SL_PROFILE" to determine which set to use.  This is a standard pattern with credential files and ruby sdks.
This allows credentials for multiple environments to be stored in the same file.